### PR TITLE
retrying otp does not call onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ to hear about issues. See also [CONTRIBUTING.md](CONTRIBUTING.md)
 * fluid client APIs for sharing data - e.g. share(value).with(atSign/s).as(keyName)
 * extend client REPL so that you can call AtClient methods (e.g. the share() above) interactively 
 
+### May 29 2022
+* Retry bug fixed in Register CLI
+* Config yaml parameters restructured and backwards compatability provided to break exsiting usages.
+* New parameter added to validateOtp method in RegisterUtil.java. The usage of this parameter is provided in java docs of the respective method.
+
+
 ### May 18 2022
 * A new CLI tool Register has been introduced which can acquire a free atsign and register it to the provided email.
 * Register CLI also handles calling the Onboard client with the cram secret which was received during the registration process.

--- a/at_client/src/main/java/org/atsign/client/cli/Register.java
+++ b/at_client/src/main/java/org/atsign/client/cli/Register.java
@@ -48,7 +48,7 @@ public class Register {
             otp = scanner.nextLine();
             System.out.println("Validating one-time-password");
             validationResponse = registerUtil.validateOtp(email, atsign, otp, registrarUrl, apiKey, false);
-
+            //if validationResponse is retry, the OTP entered is incorrect. ASk user to re-enter correct OTP
             if ("retry".equals(validationResponse)) {
                 while ("retry".equals(validationResponse)) {
                     System.out.println("Incorrect OTP entered. Re-enter the OTP: ");
@@ -57,12 +57,17 @@ public class Register {
                 }
                 scanner.close();
             }
-
+            //if validationResponse is follow-up, the atsign has been regstered to email. Again call the API with "confirmation"=true to get the cram key
+            if ("follow-up".equals(validationResponse)) {
+                validationResponse = registerUtil.validateOtp(email, atsign, otp, registrarUrl, apiKey, true);
+            }
+            //if validation response starts with @, that represents that validationResponse contains cram
             if (validationResponse.startsWith("@")) {
                 System.out.println("One-time-password verified. OK");
+                //extract cram from response
                 cramSecret = validationResponse.split(":")[1];
                 System.out.println("Got cram secret for " + atsign + " :" + cramSecret);
-
+                
                 String[] onboardArgs = new String[] { rootDomain + ":" + rootPort,
                         atsign.toString(), cramSecret };
                 Onboard.main(onboardArgs);

--- a/at_client/src/main/java/org/atsign/client/cli/Register.java
+++ b/at_client/src/main/java/org/atsign/client/cli/Register.java
@@ -24,10 +24,10 @@ public class Register {
         String otp;
         String validationResponse;
         String cramSecret;
-        String rootDomain = configReader.getProperty("rootDomain");
-        String rootPort = configReader.getProperty("rootPort");
-        String registrarUrl = configReader.getProperty("registrarUrl");
-        String apiKey = configReader.getProperty("apiKey");
+        String rootDomain = configReader.getProperty("rootServer", "domain");
+        String rootPort = configReader.getProperty("rootServer", "port");
+        String registrarUrl = configReader.getProperty("registrar", "url");
+        String apiKey = configReader.getProperty("registrar", "apiKey");
 
         if (rootDomain == null || rootPort == null || registrarUrl == null || apiKey == null) {
             System.err.println("Please make sure to set all relevant configuration in src/main/resources/config.yaml");
@@ -47,13 +47,13 @@ public class Register {
 
             otp = scanner.nextLine();
             System.out.println("Validating one-time-password");
-            validationResponse = registerUtil.validateOtp(email, atsign, otp, registrarUrl, apiKey);
+            validationResponse = registerUtil.validateOtp(email, atsign, otp, registrarUrl, apiKey, false);
 
             if ("retry".equals(validationResponse)) {
                 while ("retry".equals(validationResponse)) {
                     System.out.println("Incorrect OTP entered. Re-enter the OTP: ");
                     otp = scanner.nextLine();
-                    validationResponse = registerUtil.validateOtp(email, atsign, otp, registrarUrl, apiKey);
+                    validationResponse = registerUtil.validateOtp(email, atsign, otp, registrarUrl, apiKey, false);
                 }
                 scanner.close();
             }

--- a/at_client/src/main/java/org/atsign/client/cli/Register.java
+++ b/at_client/src/main/java/org/atsign/client/cli/Register.java
@@ -24,16 +24,16 @@ public class Register {
         String otp;
         String validationResponse;
         String cramSecret;
-        String rootDomain = configReader.getProperty("ROOT_DOMAIN");
-        String rootPort = configReader.getProperty("ROOT_PORT");
-        String registrarUrl = configReader.getProperty("REGISTRAR_URL");
-        String apiKey = configReader.getProperty("API_KEY");
-        
-        if (rootDomain == null || rootPort == null || registrarUrl == null || apiKey == null){
+        String rootDomain = configReader.getProperty("rootDomain");
+        String rootPort = configReader.getProperty("rootPort");
+        String registrarUrl = configReader.getProperty("registrarUrl");
+        String apiKey = configReader.getProperty("apiKey");
+
+        if (rootDomain == null || rootPort == null || registrarUrl == null || apiKey == null) {
             System.err.println("Please make sure to set all relevant configuration in src/main/resources/config.yaml");
             System.exit(1);
         }
-        
+
         Scanner scanner = new Scanner(System.in);
         RegisterUtil registerUtil = new RegisterUtil();
 
@@ -56,7 +56,9 @@ public class Register {
                     validationResponse = registerUtil.validateOtp(email, atsign, otp, registrarUrl, apiKey);
                 }
                 scanner.close();
-            } else if (validationResponse.startsWith("@")) {
+            }
+
+            if (validationResponse.startsWith("@")) {
                 System.out.println("One-time-password verified. OK");
                 cramSecret = validationResponse.split(":")[1];
                 System.out.println("Got cram secret for " + atsign + " :" + cramSecret);

--- a/at_client/src/main/java/org/atsign/client/cli/Register.java
+++ b/at_client/src/main/java/org/atsign/client/cli/Register.java
@@ -31,14 +31,17 @@ public class Register {
         }
         String rootPort = configReader.getProperty("rootServer", "port");
         if (rootPort == null) {
+            //reading config from older configuration syntax for backwards compatability
             rootPort = configReader.getProperty("ROOT_PORT");
         }
         String registrarUrl = configReader.getProperty("registrar", "url");
         if (registrarUrl == null) {
+            //reading config from older configuration syntax for backwards compatability
             registrarUrl = configReader.getProperty("REGISTRAR_URL");
         }
         String apiKey = configReader.getProperty("registrar", "apiKey");
         if (apiKey == null) {
+            //reading config from older configuration syntax for backwards compatability
             apiKey = configReader.getProperty("API_KEY");
         }
 
@@ -61,7 +64,7 @@ public class Register {
             otp = scanner.nextLine();
             System.out.println("Validating one-time-password");
             validationResponse = registerUtil.validateOtp(email, atsign, otp, registrarUrl, apiKey, false);
-            // if validationResponse is retry, the OTP entered is incorrect. ASk user to
+            // if validationResponse is retry, the OTP entered is incorrect. Ask user to
             // re-enter correct OTP
             if ("retry".equals(validationResponse)) {
                 while ("retry".equals(validationResponse)) {

--- a/at_client/src/main/java/org/atsign/client/cli/Register.java
+++ b/at_client/src/main/java/org/atsign/client/cli/Register.java
@@ -82,7 +82,7 @@ public class Register {
                 System.out.println("One-time-password verified. OK");
                 // extract cram from response
                 cramSecret = validationResponse.split(":")[1];
-                System.out.println("Got cram secret for " + atsign + " :" + cramSecret);
+                System.out.println("Got cram secret for " + atsign + ": " + cramSecret);
 
                 String[] onboardArgs = new String[] { rootDomain + ":" + rootPort,
                         atsign.toString(), cramSecret };

--- a/at_client/src/main/java/org/atsign/client/cli/Register.java
+++ b/at_client/src/main/java/org/atsign/client/cli/Register.java
@@ -25,9 +25,22 @@ public class Register {
         String validationResponse;
         String cramSecret;
         String rootDomain = configReader.getProperty("rootServer", "domain");
+        if (rootDomain == null) {
+            //reading config from older configuration syntax for backwards compatability
+            rootDomain = configReader.getProperty("ROOT_DOMAIN");
+        }
         String rootPort = configReader.getProperty("rootServer", "port");
+        if (rootPort == null) {
+            rootPort = configReader.getProperty("ROOT_PORT");
+        }
         String registrarUrl = configReader.getProperty("registrar", "url");
+        if (registrarUrl == null) {
+            registrarUrl = configReader.getProperty("REGISTRAR_URL");
+        }
         String apiKey = configReader.getProperty("registrar", "apiKey");
+        if (apiKey == null) {
+            apiKey = configReader.getProperty("API_KEY");
+        }
 
         if (rootDomain == null || rootPort == null || registrarUrl == null || apiKey == null) {
             System.err.println("Please make sure to set all relevant configuration in src/main/resources/config.yaml");
@@ -48,7 +61,8 @@ public class Register {
             otp = scanner.nextLine();
             System.out.println("Validating one-time-password");
             validationResponse = registerUtil.validateOtp(email, atsign, otp, registrarUrl, apiKey, false);
-            //if validationResponse is retry, the OTP entered is incorrect. ASk user to re-enter correct OTP
+            // if validationResponse is retry, the OTP entered is incorrect. ASk user to
+            // re-enter correct OTP
             if ("retry".equals(validationResponse)) {
                 while ("retry".equals(validationResponse)) {
                     System.out.println("Incorrect OTP entered. Re-enter the OTP: ");
@@ -57,17 +71,19 @@ public class Register {
                 }
                 scanner.close();
             }
-            //if validationResponse is follow-up, the atsign has been regstered to email. Again call the API with "confirmation"=true to get the cram key
+            // if validationResponse is follow-up, the atsign has been regstered to email.
+            // Again call the API with "confirmation"=true to get the cram key
             if ("follow-up".equals(validationResponse)) {
                 validationResponse = registerUtil.validateOtp(email, atsign, otp, registrarUrl, apiKey, true);
             }
-            //if validation response starts with @, that represents that validationResponse contains cram
+            // if validation response starts with @, that represents that validationResponse
+            // contains cram
             if (validationResponse.startsWith("@")) {
                 System.out.println("One-time-password verified. OK");
-                //extract cram from response
+                // extract cram from response
                 cramSecret = validationResponse.split(":")[1];
                 System.out.println("Got cram secret for " + atsign + " :" + cramSecret);
-                
+
                 String[] onboardArgs = new String[] { rootDomain + ":" + rootPort,
                         atsign.toString(), cramSecret };
                 Onboard.main(onboardArgs);

--- a/at_client/src/main/java/org/atsign/client/util/RegisterUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/RegisterUtil.java
@@ -108,12 +108,12 @@ public class RegisterUtil {
      * @throws IOException
      * @throws AtException
      */
-    public String validateOtp(String email, AtSign atsign, String otp, String registrarUrl, String apiKey)
+    public String validateOtp(String email, AtSign atsign, String otp, String registrarUrl, String apiKey, boolean confirmation)
             throws IOException, AtException {
         URL validateOtpUrl = new URL(registrarUrl + Constants.VALIDATE_OTP);
         HttpsURLConnection httpsConnection = (HttpsURLConnection) validateOtpUrl.openConnection();
         String params = "{\"atsign\":\"" + atsign.withoutPrefix() + "\", \"email\":\"" + email + "\", \"otp\":\"" + otp
-                + "\", \"confirmation\":\"" + "true\"}";
+                + "\", \"confirmation\":\"" + confirmation + "\"}";
         httpsConnection.setRequestMethod("POST");
         httpsConnection.setRequestProperty("Content-Type", "application/json");
         httpsConnection.setRequestProperty("Authorization", apiKey);

--- a/at_client/src/main/java/org/atsign/client/util/RegisterUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/RegisterUtil.java
@@ -180,6 +180,8 @@ public class RegisterUtil {
                 return responseDataStringObject.get("cramkey");
             } else if (responseDataStringObject.containsKey("newAtsign")
                     && responseDataStringObject.get("newAtsign").equals(atsign.withoutPrefix())) {
+                        System.out.println(responseDataStringObject + "\n");
+                        System.out.println(responseDataStringObject.get("atsigns"));
                 return "follow-up";
             } else if (responseDataStringObject.containsKey("message")
                     && responseDataStringObject.get("message").contains("Try again")) {

--- a/at_client/src/main/java/org/atsign/client/util/RegisterUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/RegisterUtil.java
@@ -7,15 +7,12 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import javax.net.ssl.HttpsURLConnection;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.atsign.common.AtException;
 import org.atsign.common.AtSign;
@@ -139,16 +136,14 @@ public class RegisterUtil {
      *                     HTTP_OK/Status_200.
      */
     public String validateOtp(String email, AtSign atsign, String otp, String registrarUrl, String apiKey,
-            boolean... confirmation)
+            Boolean confirmation)
             throws IOException, AtException {
-        // setting default confirmation to true in case it's not provided
-        Boolean defaultConfirmation = (confirmation.length == 0) ? true : confirmation[0];
         // creation of a new URL object from provided URL parameters
         URL validateOtpUrl = new URL(registrarUrl + Constants.VALIDATE_OTP);
         // opens a stream type connetion to the above URL
         HttpsURLConnection httpsConnection = (HttpsURLConnection) validateOtpUrl.openConnection();
         String params = "{\"atsign\":\"" + atsign.withoutPrefix() + "\", \"email\":\"" + email + "\", \"otp\":\"" + otp
-                + "\", \"confirmation\":\"" + defaultConfirmation + "\"}";
+                + "\", \"confirmation\":\"" + confirmation + "\"}";
         httpsConnection.setRequestMethod("POST");
         httpsConnection.setRequestProperty("Content-Type", "application/json");
         httpsConnection.setRequestProperty("Authorization", apiKey);
@@ -204,6 +199,12 @@ public class RegisterUtil {
         } else {
             throw new AtException(httpsConnection.getResponseCode() + " " + httpsConnection.getResponseMessage());
         }
+    }
+
+    // method added for backwards compatability. will be removed in further updates
+    public String validateOtp(String email, AtSign atsign, String otp, String registrarUrl, String apiKey)
+            throws IOException, AtException {
+        return validateOtp(email, atsign, otp, registrarUrl, apiKey, true);
     }
 
 }

--- a/at_client/src/main/java/org/atsign/client/util/RegisterUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/RegisterUtil.java
@@ -26,9 +26,11 @@ public class RegisterUtil {
      * @param apiKey       - API key to authenticate connection to atsign registrar
      *                     API
      * @return free atsign
-     * @throws AtException
-     * @throws MalformedURLException
-     * @throws IOException
+     * @throws AtException           thrown if HTTPS_REQUEST was not successful
+     * @throws MalformedURLException thrown in case of improper URL params provided
+     * @throws IOException           if anything goes wrong while handling I/O
+     *                               streams from
+     *                               HttpsURLConnection
      */
 
     public String getFreeAtsign(String registrarUrl, String apiKey)
@@ -65,10 +67,12 @@ public class RegisterUtil {
      * @param registrarUrl - URL of the atsign registrar API
      * @param apiKey       - API key to authenticate connection to atsign registrar
      *                     API
-     * @return
-     * @throws AtException
-     * @throws MalformedURLException
-     * @throws IOException
+     * @return true if one-time-password sent successfully, false otherwise
+     * @throws AtException           thrown if HTTPS_REQUEST was not successfull
+     * @throws MalformedURLException thrown in case of improper URL params provided
+     * @throws IOException           if anything goes wrong while handling I/O
+     *                               streams from
+     *                               HttpsURLConnection
      */
     public Boolean registerAtsign(String email, AtSign atsign, String registrarUrl, String apiKey)
             throws AtException, MalformedURLException, IOException {
@@ -119,9 +123,11 @@ public class RegisterUtil {
      *                     case API will return cram key if the user is new
      *                     otherwise will return list of already existing atsigns.
      *                     If the user already has existing atsigns user will have
-     *                     to select a listed atsign and place a second call to the
-     *                     same API endpoint with confirmation set to true with
-     *                     previously received OTP.
+     *                     to select a listed atsign old/new and place a second call
+     *                     to the same API endpoint with confirmation set to true
+     *                     with previously received OTP. The second follow-up call 
+     *                     is automated by this client using new atsign for user
+     *                     simplicity
      * @return Case 1("verified") - the API has registered the atsign to
      *         provided email and cramkey present in HTTP_RESPONSE Body.
      *         Case 2("follow-up"): User already has existing atsigns and new atsign
@@ -129,15 +135,18 @@ public class RegisterUtil {
      *         one
      *         of exsting listed atsigns with confirmation set to true.
      *         Case 3("retry"): Incorrect OTP send request again with correct OTP.
-     * @throws IOException if anything goes wrong while handling I/O streams from
-     *                     HttpsURLConnection.
-     * @throws AtException Case 1: If user has exhausted 10 free atsign quota
-     *                     Case 2: If API response is anything other than
-     *                     HTTP_OK/Status_200.
+     * @throws IOException           thrown if anything goes wrong while handling I/O
+     *                               streams from
+     *                               HttpsURLConnection.
+     * @throws AtException           Case 1: If user has exhausted 10 free atsign
+     *                               quota
+     *                               Case 2: If API response is anything other than
+     *                               HTTP_OK/Status_200.
+     * @throws MalformedURLException thrown in case of improper URL params provided
      */
     public String validateOtp(String email, AtSign atsign, String otp, String registrarUrl, String apiKey,
             Boolean confirmation)
-            throws IOException, AtException {
+            throws IOException, AtException, MalformedURLException {
         // creation of a new URL object from provided URL parameters
         URL validateOtpUrl = new URL(registrarUrl + Constants.VALIDATE_OTP);
         // opens a stream type connetion to the above URL

--- a/at_client/src/main/java/org/atsign/config/ConfigReader.java
+++ b/at_client/src/main/java/org/atsign/config/ConfigReader.java
@@ -13,15 +13,22 @@ import org.yaml.snakeyaml.Yaml;
  * Loads, reads and returns properties from the configuration file in the resources
  */
 public class ConfigReader {
-    private Map<String, Map<String, String>> config;
+    private Map<String, Object> config;
     private Map<String,String>propertyMap;
 
     public String getProperty(String property, String subProperty) throws StreamReadException, DatabindException, FileNotFoundException{
         if (config == null){
             loadConfig();
         }
-        propertyMap = config.get(property);
+        propertyMap = (Map<String, String>) config.get(property);
         return propertyMap.get(subProperty);
+    }
+
+    public String getProperty(String property) throws StreamReadException, DatabindException, FileNotFoundException{
+        if (config == null){
+            loadConfig();
+        }
+        return (String) config.get(property);
     }
 
     /**

--- a/at_client/src/main/java/org/atsign/config/ConfigReader.java
+++ b/at_client/src/main/java/org/atsign/config/ConfigReader.java
@@ -13,13 +13,15 @@ import org.yaml.snakeyaml.Yaml;
  * Loads, reads and returns properties from the configuration file in the resources
  */
 public class ConfigReader {
-    private Map<String, String> config;
+    private Map<String, Map<String, String>> config;
+    private Map<String,String>propertyMap;
 
-    public String getProperty(String property) throws StreamReadException, DatabindException, FileNotFoundException{
+    public String getProperty(String property, String subProperty) throws StreamReadException, DatabindException, FileNotFoundException{
         if (config == null){
             loadConfig();
         }
-        return config.get(property);
+        propertyMap = config.get(property);
+        return propertyMap.get(subProperty);
     }
 
     /**

--- a/at_client/src/main/resources/config.yaml
+++ b/at_client/src/main/resources/config.yaml
@@ -5,3 +5,9 @@ rootServer:
 registrar:
   url: "https://my.atsign.wtf/api/app/v2" ##staging registrar url. please use "https://my.atsign.com/api/app/v2" to use the production registrar api
   apiKey: "477b-876u-bcez-c42z-6a3d" ##staging api key. please obtain a key to the production registrar api and replace it
+
+##the configurations below are provided for backwards-compatability and will be deprecated in further updates. Kindly use the config structure above for smooth functioning
+API_KEY: "477b-876u-bcez-c42z-6a3d"
+ROOT_DOMAIN: "root.atsign.wtf"
+ROOT_PORT: "64" 
+REGISTRAR_URL: "https://my.atsign.wtf/api/app/v2"

--- a/at_client/src/main/resources/config.yaml
+++ b/at_client/src/main/resources/config.yaml
@@ -1,4 +1,7 @@
-apiKey: "477b-876u-bcez-c42z-6a3d" ##staging api key. please obtain a key to the production registrar api and replace it
-rootDomain: "root.atsign.wtf" ##staging root server. use "root.atsign.org" to use the production root domain
-rootPort: "64" 
-registrarUrl: "https://my.atsign.wtf/api/app/v2" ##staging registrar url. please use "https://my.atsign.com/api/app/v2" to use the production registrar api
+rootServer:
+  domain: "root.atsign.wtf" ##staging root server. use "root.atsign.org" to use the production root domain
+  port: "64"
+
+registrar:
+  url: "https://my.atsign.wtf/api/app/v2" ##staging registrar url. please use "https://my.atsign.com/api/app/v2" to use the production registrar api
+  apiKey: "477b-876u-bcez-c42z-6a3d" ##staging api key. please obtain a key to the production registrar api and replace it

--- a/at_client/src/main/resources/config.yaml
+++ b/at_client/src/main/resources/config.yaml
@@ -1,4 +1,4 @@
-API_KEY: "477b-876u-bcez-c42z-6a3d" ##staging api key. please obtain a key to the production registrar api and replace it
-ROOT_DOMAIN: "root.atsign.wtf" ##staging root server. use "root.atsign.org" to use the production root domain
-ROOT_PORT: "64" 
-REGISTRAR_URL: "https://my.atsign.wtf/api/app/v2" ##staging registrar url. please use "https://my.atsign.com/api/app/v2" to use the production registrar api
+apiKey: "477b-876u-bcez-c42z-6a3d" ##staging api key. please obtain a key to the production registrar api and replace it
+rootDomain: "root.atsign.wtf" ##staging root server. use "root.atsign.org" to use the production root domain
+rootPort: "64" 
+registrarUrl: "https://my.atsign.wtf/api/app/v2" ##staging registrar url. please use "https://my.atsign.com/api/app/v2" to use the production registrar api


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or


Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_java/issues/14
**- What I did**

- Solved a bug where re-entering otp does not call onboarding
- Handled a case when user exhausts their quota of free atsigns by displaying appropriate message
- Also restructure config yaml and changed the config variables to camelCase

**- How I did it**

- reposition if-else blocks so that the block calling onboarding class is executed every time
- calling API to check if they have exhausted free atsign quota before trying to register it to a users email

**- How to verify it**

- use register CLI and enter incorrect otp and then enter correct otp. Expected behaviour is that onboarding is successfully completed
- try registering a new atsign with an email that has exhausted free atsign limit, the CLI should throw an exception "free atsign limit exhausted"

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->