### PR TITLE
PublicKey and KeyBuilder tests

### DIFF
--- a/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
@@ -396,7 +396,13 @@ public class AtClientImpl implements AtClient {
         throw new RuntimeException("Not Implemented");
     }
 
-    private String _get(PublicKey key) throws AtException {throw new RuntimeException("Not Implemented");}
+    private String _get(PublicKey key) throws AtException {
+        String verbCommand = "llookup:" + key.toString();
+        Response rawResponse = secondary.executeCommand(verbCommand, true);
+        String data = rawResponse.data;
+        return data;
+    }
+
     private String _put(PublicKey publicKey, String value) {throw new RuntimeException("Not Implemented");}
     private String _delete(PublicKey key) {
         throw new RuntimeException("Not Implemented");

--- a/at_client/src/main/java/org/atsign/common/KeyBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/KeyBuilders.java
@@ -86,7 +86,11 @@ public class KeyBuilders {
     /// Builder to build the public keys
     public static class PublicKeyBuilder extends CachedKeyBuilder implements KeyBuilder {
         public PublicKeyBuilder() {
-            _atKey = new PublicKey();
+            this(defaultAtSign);
+        }
+
+        public PublicKeyBuilder(AtSign sharedBy) {
+            _atKey = new PublicKey(sharedBy);
             _atKey.metadata.isPublic = true;
             _atKey.metadata.isHidden = false;
         }

--- a/at_client/src/test/java/org/atsign/common/KeyBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/KeyBuildersTest.java
@@ -37,6 +37,26 @@ public class KeyBuildersTest {
         assertEquals(null, publicKey.sharedWith); // null
     }
 
+    @Test
+    public void buildSharedKeyTest() {
+        // want to build:
+        String want = "@bob:shared_key@alice"; // `shared_key` is sharedBy `@alice` and sharedWith `@bob`
+
+        // variables 
+        String keyName = "shared_key";
+        String sharedByStr = "@alice";
+        String sharedWithStr = "@bob";
+
+        // build SharedKey instance
+        AtSign sharedBy = new AtSign(sharedByStr);
+        AtSign sharedWith = new AtSign(sharedWithStr);
+
+        SharedKey sharedKey = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key(keyName).build();
+
+        assertEquals(want, sharedKey.toString());
+        assertEquals(false, sharedKey.metadata.isPublic);
+    }
+
     @After
     public void tearDown() {
 

--- a/at_client/src/test/java/org/atsign/common/KeyBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/KeyBuildersTest.java
@@ -1,0 +1,45 @@
+package org.atsign.common;
+
+
+import static org.junit.Assert.assertEquals;
+
+import org.atsign.common.Keys.PublicKey;
+import org.atsign.common.Keys.SharedKey;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KeyBuildersTest {
+    
+    @Before
+    public void setUp() {
+
+    }
+
+    @Test
+    public void buildPublicKeyTest() {
+        // want to build: 
+        String want = "public:publickey@alice"; // this key is public (denoted by `public:` and is sharedBy `@alice` because this atSign is the owner).
+
+        // variables
+        String keyName = "publickey";
+        String atSignStr = "@alice";
+        
+        // build PublicKey instance
+        AtSign sharedBy = new AtSign(atSignStr);
+        PublicKey publicKey = new KeyBuilders.PublicKeyBuilder(sharedBy).key(keyName).build();
+
+        assertEquals(want, publicKey.toString()); // public:publickey@alice
+        assertEquals(true, publicKey.metadata.isPublic); // metadata.isPublic
+        assertEquals(false, publicKey.metadata.isHidden); // metadata.isHidden
+        assertEquals(keyName, publicKey.name); // publickey
+        assertEquals(atSignStr, publicKey.sharedBy.atSign); // @alice
+        assertEquals(null, publicKey.sharedWith); // null
+    }
+
+    @After
+    public void tearDown() {
+
+    }
+
+}


### PR DESCRIPTION
### What this branch is for
- [x] Build a `PublicKey` using `new KeyBuilders.PublicKey()....build()`
- [x] Make tests for `PublicKey` building (*also made `SharedKey` building test)
- [x] Implement `_get(PublicKey key)` in AtClientImpl
- [ ] Implement PublicKey getting in the `Get.java` command-line program.