### PR TITLE
feat: `AtClientValidation.java` and tests

### DIFF
--- a/at_client/src/main/java/org/atsign/client/util/AtClientValidation.java
+++ b/at_client/src/main/java/org/atsign/client/util/AtClientValidation.java
@@ -1,0 +1,119 @@
+package org.atsign.client.util;
+
+import java.io.IOException;
+
+import org.atsign.client.api.Secondary;
+import org.atsign.common.AtException;
+import org.atsign.common.AtSign;
+import org.atsign.common.Keys.AtKey;
+import org.atsign.common.Keys.Metadata;
+
+public class AtClientValidation {
+
+    /**
+     * @param keyName // e.g. "test" (not the fullKeyName like "public:test@bob")
+     * @throws AtException
+     */
+    public static void validateKeyName(String keyName) throws AtException {
+        // key cannot be null and cannot be the empty string (length 0)
+        if (keyName == null || keyName.isEmpty()) {
+            throw new AtException("Key cannot be null or empty");
+        }
+
+        // key cannot have spaces
+        if (keyName.contains(" ")) {
+            throw new AtException("Key cannot have spaces");
+        }
+
+        // Key cannot contain @
+        if (keyName.contains("@")) {
+            throw new AtException("Key cannot contain @");
+        }
+    }
+
+    /**
+     * 
+     * @param metadata Metadata object to validate
+     * @throws AtException if metadata is null or has invalid values
+     */
+    public static void validateMetadata(Metadata metadata) throws AtException {
+        // null check
+        if (metadata == null) {
+            throw new AtException("Metadata cannot be null");
+        }
+
+        // validate ttl
+        if (metadata.ttl == null || (metadata.ttl < 0)) {
+            throw new AtException("Ttl cannot be null and cannot be negative");
+        }
+
+        // validate ttb
+        if (metadata.ttb == null || metadata.ttb < 0) {
+            throw new AtException("Ttb cannot be null and cannot be negative");
+        }
+
+        // validate ttr
+        if (metadata.ttr == null || metadata.ttr < -1) {
+            throw new AtException("Ttb cannot be null and cannot be < -1");
+        }
+
+    }
+
+    /**
+     * Checks if an atSign exists on a root server
+     * 
+     * @param atSign  atSign object to check for existence
+     * @param rootUrl rootUrl of the root server for atSign existence
+     * @throws AtException if atSign does not exist/address could not be found, if
+     *                     atSign object is empty,
+     */
+    public static void atSignExists(AtSign atSign, String rootUrl) throws AtException {
+        if(atSign == null) {
+            throw new AtException("atSign cannot be null");
+        }
+        if (atSign.toString().isEmpty()) {
+            throw new AtException("atSign cannot be empty");
+        }
+        Secondary.AddressFinder finder = ArgsUtil.createAddressFinder(rootUrl);
+        try {
+            finder.findSecondary(atSign);
+        } catch (IOException e) {
+            throw new AtException("Could not find secondary of atSign: " + atSign.toString());
+        }
+    }
+
+    public static void atSignExists(AtSign atSign, String rootDomain, String rootPort) throws AtException {
+        atSignExists(atSign, rootDomain + ":" + rootPort);
+    }
+
+    /**
+     * Validate if an AtKey object is valid
+     * 1. checks if atKey.name is a valid keyName
+     * 2. checks if atKey.metadata has valid values
+     * 3. checks if atKey.sharedWith atSign is valid (if it exists)
+     * 
+     * @param atKey   AtKey object created usually through KeyBuilders
+     * @param rootUrl RootURL of the Root Server (e.g. "root.atsign.org:64")
+     * @throws AtException if the AtKey is invalid
+     */
+    public static void validateAtKey(AtKey atKey, String rootUrl) throws AtException {
+
+        // 1. null check
+        if(atKey == null) {
+            throw new AtException("AtKey cannot be null");
+        }
+
+        // 2. validate key name
+        validateKeyName(atKey.name);
+
+        // 3. validate metadata
+        validateMetadata(atKey.metadata);
+
+        // 4. validate sharedWith exists
+        if (atKey.sharedWith != null) {
+            atSignExists(atKey.sharedWith, rootUrl);
+        }
+
+    }
+
+}

--- a/at_client/src/main/java/org/atsign/client/util/AtClientValidation.java
+++ b/at_client/src/main/java/org/atsign/client/util/AtClientValidation.java
@@ -68,11 +68,11 @@ public class AtClientValidation {
      *                     atSign object is empty,
      */
     public static void atSignExists(AtSign atSign, String rootUrl) throws AtException {
-        if(atSign == null) {
-            throw new AtException("atSign cannot be null");
+        if(atSign == null || atSign.toString().isEmpty()) {
+            throw new AtException("atSign cannot be null or empty");
         }
-        if (atSign.toString().isEmpty()) {
-            throw new AtException("atSign cannot be empty");
+        if (rootUrl == null || rootUrl.isEmpty()) {
+            throw new AtException("rootUrl cannot be null or empty");
         }
         Secondary.AddressFinder finder = ArgsUtil.createAddressFinder(rootUrl);
         try {
@@ -101,6 +101,10 @@ public class AtClientValidation {
         // 1. null check
         if(atKey == null) {
             throw new AtException("AtKey cannot be null");
+        }
+
+        if(rootUrl == null || rootUrl.isEmpty()) {
+            throw new AtException("RootURL cannot be null or empty");
         }
 
         // 2. validate key name

--- a/at_client/src/test/java/org/atsign/common/AtClientValidationTest.java
+++ b/at_client/src/test/java/org/atsign/common/AtClientValidationTest.java
@@ -1,0 +1,242 @@
+package org.atsign.common;
+
+import static org.junit.Assert.assertThrows;
+
+import org.atsign.client.util.AtClientValidation;
+import org.atsign.common.Keys.Metadata;
+import org.atsign.common.Keys.PublicKey;
+import org.atsign.common.Keys.SelfKey;
+import org.atsign.common.Keys.SharedKey;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AtClientValidationTest {
+
+    @Before
+    public void setUp() {
+    }
+
+    // valid key names (like "test", but not "cached:public:test@bob" <-- these key
+    // names will always fail this test)
+    @Test
+    public void validateKeyNameTest() {
+        // null key name
+        assertThrows(AtException.class, () -> {
+            String keyName = null;
+            AtClientValidation.validateKeyName(keyName);
+        });
+
+        // empty key name
+        assertThrows(AtException.class, () -> {
+            String keyName = "";
+            AtClientValidation.validateKeyName(keyName);
+        });
+
+        // key name with @
+        assertThrows(AtException.class, () -> {
+            String keyName = "test@bob";
+            AtClientValidation.validateKeyName(keyName);
+        });
+
+        // key name with spaces
+        assertThrows(AtException.class, () -> {
+            String keyName = " te st ";
+            AtClientValidation.validateKeyName(keyName);
+        });
+
+    }
+
+    // valid metadata (null check, ttl, ttb, ttr)
+    @Test
+    public void validateMetadataTest() {
+
+        // null metadata
+        assertThrows(AtException.class, () -> {
+            Metadata metadata = null;
+            AtClientValidation.validateMetadata(metadata);
+        });
+
+        // null ttl
+        assertThrows(AtException.class, () -> {
+            Metadata metadata = new Metadata();
+            metadata.ttl = null;
+            metadata.ttb = 0;
+            metadata.ttr = -1;
+            AtClientValidation.validateMetadata(metadata);
+        });
+
+        // negative ttl
+        assertThrows(AtException.class, () -> {
+            Metadata metadata = new Metadata();
+            metadata.ttl = -100;
+            metadata.ttb = 0;
+            metadata.ttr = -1;
+            AtClientValidation.validateMetadata(metadata);
+        });
+
+        // null ttb
+        assertThrows(AtException.class, () -> {
+            Metadata metadata = new Metadata();
+            metadata.ttl = 0;
+            metadata.ttb = null;
+            metadata.ttr = -1;
+            AtClientValidation.validateMetadata(metadata);
+        });
+
+        // negative ttb
+        assertThrows(AtException.class, () -> {
+            Metadata metadata = new Metadata();
+            metadata.ttl = 0;
+            metadata.ttb = -100;
+            metadata.ttr = -1;
+            AtClientValidation.validateMetadata(metadata);
+        });
+
+        // null ttr
+        assertThrows(AtException.class, () -> {
+            Metadata metadata = new Metadata();
+            metadata.ttl = 0;
+            metadata.ttb = 0;
+            metadata.ttr = null;
+            AtClientValidation.validateMetadata(metadata);
+        });
+
+        // ttr < -1
+        assertThrows(AtException.class, () -> {
+            Metadata metadata = new Metadata();
+            metadata.ttl = 0;
+            metadata.ttb = 0;
+            metadata.ttr = -2;
+            AtClientValidation.validateMetadata(metadata);
+        });
+    }
+
+    // atSign exists (uses secondaryaddress.finder)
+    @Test
+    public void atSignExistsTest() {
+
+        final String VALID_ROOT_URL = "root.atsign.org:64"; // prod rootUrl
+
+        // null atSign
+        assertThrows(AtException.class, () -> {
+            AtSign atSign = null;
+            AtClientValidation.atSignExists(atSign, VALID_ROOT_URL);
+        });
+
+        // empty atSign
+        assertThrows(AtException.class, () -> {
+            AtSign atSign = new AtSign("");
+            AtClientValidation.atSignExists(atSign, VALID_ROOT_URL);
+        });
+
+        // root does not contain atSign
+        assertThrows(AtException.class, () -> {
+            AtSign atSign = new AtSign("someAtSignThatDNE456");
+            AtClientValidation.atSignExists(atSign, VALID_ROOT_URL);
+        });
+
+        // invalid root
+        assertThrows(AtException.class, () -> {
+            AtSign atSign = new AtSign("smoothalligator");
+            AtClientValidation.atSignExists(atSign, "invalidroot:32123");
+        });
+
+    }
+
+    // validate AtKey object is ready (checks atKey.name validity, metadata
+    // validity, and if sharedWith exists)
+    @Test
+    public void validateAtKeyTest() {
+        final String ROOT_URL = "root.atsign.org:64";
+
+        // ====================================
+        // PublicKey tests
+        // ====================================
+
+        // null publicKey
+        assertThrows(AtException.class, () -> {
+            PublicKey publicKey = null;
+            AtClientValidation.validateAtKey(publicKey, ROOT_URL);
+        });
+
+        // public key with invalid ttr
+        assertThrows(AtException.class, () -> {
+            AtSign sharedBy = new AtSign("@bob");
+            PublicKey publicKey = new KeyBuilders.PublicKeyBuilder(sharedBy).key("test").build();
+            publicKey.metadata.ttr = -2;
+            AtClientValidation.validateAtKey(publicKey, "");
+        });
+
+        // ====================================
+        // SelfKey tests
+        // ====================================
+
+        // null selfKey
+        assertThrows(AtException.class, () -> {
+            SelfKey selfKey = null;
+            AtClientValidation.validateAtKey(selfKey, ROOT_URL);
+        });
+
+        // self key with invalid keyName
+        assertThrows(AtException.class, () -> {
+            AtSign sharedBy = new AtSign("@bob");
+            SelfKey selfKey = new KeyBuilders.SelfKeyBuilder(sharedBy).key("t est").build();
+            AtClientValidation.validateAtKey(selfKey, ROOT_URL);
+        });
+
+        // self key with non-existent sharedWith atSign in root
+        assertThrows(AtException.class, () -> {
+            AtSign sharedBy = new AtSign("@nonexistentatsign");
+            AtSign sharedWith = new AtSign("@nonexistentatsign"); // atSign does not exist in root
+            SelfKey selfKey = new KeyBuilders.SelfKeyBuilder(sharedBy, sharedWith).key("test").build();
+            AtClientValidation.validateAtKey(selfKey, ROOT_URL);
+        });
+
+        // ====================================
+        // SharedKey tests
+        // ====================================
+
+        // null shared key test
+        assertThrows(AtException.class, () -> {
+            SharedKey sharedKey = null;
+            AtClientValidation.validateAtKey(sharedKey, ROOT_URL);
+        });
+
+        // shared key with ttr < -1
+        assertThrows(AtException.class, () -> {
+            AtSign sharedBy = new AtSign("@bob");
+            AtSign sharedWith = new AtSign("@alice");
+            SharedKey sharedKey = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key("test").build();
+            sharedKey.metadata.ttr = -22323;
+            AtClientValidation.validateAtKey(sharedKey, ROOT_URL);
+        });
+
+        // shared key with invalid keyName
+        assertThrows(AtException.class, () -> {
+            AtSign sharedBy = new AtSign("@bob");
+            AtSign sharedWith = new AtSign("@alice");
+            SharedKey sharedKey = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key("t est").build();
+            AtClientValidation.validateAtKey(sharedKey, ROOT_URL);
+        });
+
+        // shared key with invalid sharedWith atSign (atSign dne in root)
+        assertThrows(AtException.class, () -> {
+            AtSign sharedBy = new AtSign("@wildgreen");
+            AtSign sharedWith = new AtSign("@nonexistentatsign"); // atSign does not exist in root
+            SharedKey sharedKey = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key("test").build();
+            AtClientValidation.validateAtKey(sharedKey, ROOT_URL);
+        });
+
+        // ====================================
+        // PrivateHiddenKey tests
+        // ====================================
+
+        // TODO
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+}

--- a/at_client/src/test/java/org/atsign/common/AtClientValidationTest.java
+++ b/at_client/src/test/java/org/atsign/common/AtClientValidationTest.java
@@ -228,6 +228,14 @@ public class AtClientValidationTest {
             AtClientValidation.validateAtKey(sharedKey, ROOT_URL);
         });
 
+        // empty root url
+        assertThrows(AtException.class, () -> {
+            AtSign sharedBy = new AtSign("@bob");
+            AtSign sharedWith = new AtSign("@alice");
+            SharedKey sharedKey = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key("test").build();
+            AtClientValidation.validateAtKey(sharedKey, "");
+        });
+
         // ====================================
         // PrivateHiddenKey tests
         // ====================================


### PR DESCRIPTION
## `AtClientValidation.java`

- [x] `AtClientValidation.validateKeyName(String keyName)` - validates the key name (e.g. "test", "location", "phone" all pass, but "te s t", "loc@tion" do not pass).
- [x] `AtClientValidation.validateMetadata(Metadata metadata)` - checks for valid ttl >= 0, ttb >= 0, ttr >= -1
- [x] `AtClientValidation.atSignExists(AtSign atSign, String rootUrl)` - checks if the `atSign` exists in the root server with url `rootUrl`
- [x] `AtClientValidation.validateAtKey(AtKey atKey, String rootUrl)` - combination of all validation methods above (checks for key name, checks for metadata, checks for atSignExists)
- [x] All validation methods do null checks and `String.isEmpty` checks


## `AtClientValidationTest.java`

- [x] test `AtClientValidation.validateKeyName(String)`
- [x] test `AtClientValidation.validateMetadata(Metadata)`
- [x] test `AtClientValidation.atSignExists(AtSign, String)`
- [x] test `AtClientValidation.validateAtKey(AtKey, String)` 