### PR TITLE
feat: VerbBuilders to more easily construct AtProtocol commands 

### DIFF
--- a/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
@@ -504,36 +504,21 @@ public class AtClientImpl implements AtClient {
             metaBuilder.with(key, LlookupVerbBuilder.Type.METADATA);
             metaCommand = metaBuilder.build();
         } else {
-            // check if key is cached
-            LlookupVerbBuilder dataBuilder = new LlookupVerbBuilder();
-            dataBuilder.with(key, LlookupVerbBuilder.Type.NONE);
-            dataBuilder.setIsCached(true);
+            // plookup
+            PlookupVerbBuilder dataBuilder = new PlookupVerbBuilder();
+            dataBuilder.with(key, PlookupVerbBuilder.Type.NONE);
             dataCommand = dataBuilder.build();
 
-            LlookupVerbBuilder metaBuilder = new LlookupVerbBuilder();
-            metaBuilder.with(key, LlookupVerbBuilder.Type.METADATA);
-            metaBuilder.setIsCached(true);
+            PlookupVerbBuilder metaBuilder = new PlookupVerbBuilder();
+            metaBuilder.with(key, PlookupVerbBuilder.Type.METADATA);
             metaCommand = metaBuilder.build();
         }
 
         // 2. get the data
-        // llookup:<fullKeyName> or llookup:cached:<key>
+        // llookup:<fullKeyName> or plookup:<fullKeyName>
         Secondary.Response dataResponse = secondary.executeCommand(dataCommand, false);
         if(dataResponse.isError) {
-            // 2.A. if data is not found, plookup
-            PlookupVerbBuilder dataBuilder = new PlookupVerbBuilder();
-            dataBuilder.with(key, PlookupVerbBuilder.Type.NONE);
-            dataCommand = dataBuilder.build(); // plookup:<fullKeyName>
-            
-            PlookupVerbBuilder metaBuilder = new PlookupVerbBuilder();
-            metaBuilder.with(key, PlookupVerbBuilder.Type.METADATA);
-            metaCommand = metaBuilder.build(); // plookup:meta:<fullKeyName>
-            
-            dataResponse = secondary.executeCommand(dataCommand, false);
-            if(dataResponse.isError) {   
-                throw new AtException("Failed to run command " + dataCommand + " : " + dataResponse.error);
-            }
-
+            throw new AtException("Failed to run command " + dataCommand + " : " + dataResponse.error);
         }
 
         responseData = dataResponse.data;

--- a/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
@@ -11,6 +11,11 @@ import org.atsign.common.Keys;
 import org.atsign.common.ResponseTransformers;
 import org.atsign.common.ResponseTransformers.LlookupMetadataResponseTransformer;
 import org.atsign.common.ResponseTransformers.ScanResponseTransformer;
+import org.atsign.common.VerbBuilders.DeleteVerbBuilder;
+import org.atsign.common.VerbBuilders.LlookupVerbBuilder;
+import org.atsign.common.VerbBuilders.PlookupVerbBuilder;
+import org.atsign.common.VerbBuilders.ScanVerbBuilder;
+import org.atsign.common.VerbBuilders.UpdateVerbBuilder;
 
 import static org.atsign.common.Keys.*;
 
@@ -410,41 +415,44 @@ public class AtClientImpl implements AtClient {
     }
 
     private String _get(SelfKey key) throws AtException {
-        // 1. find out if data is encrypted
-        String metaLlookupCommand = "llookup:meta:" + key;
-        Secondary.Response rawResponseMeta = secondary.executeCommand(metaLlookupCommand, false);
-        if (rawResponseMeta.isError) {
-            throw new AtException("Failed to " + metaLlookupCommand + " : " + rawResponseMeta.error);
-        }
-        Metadata llookupMetadata = null;
-        try {
-            llookupMetadata = Metadata.fromString(rawResponseMeta);
-        } catch (ParseException e) {
-            throw new AtException("Failed to " + metaLlookupCommand + " : " + e.getMessage(), e);
-        }
-        key.metadata = Metadata.squash(key.metadata, llookupMetadata);
-        boolean isEncrypted = llookupMetadata.isEncrypted;
-
-        // 2. get the value
+        // 1. llookup:<fullKeyName>
         String value = null;
-        String command = "llookup:" + key;
+        LlookupVerbBuilder builder = new LlookupVerbBuilder();
+        builder.with(key, LlookupVerbBuilder.Type.NONE);
+        String command = builder.build();
         Secondary.Response rawResponse = secondary.executeCommand(command, false);
         if (rawResponse.isError) {
             throw new AtException("Failed to " + command + " : " + rawResponse.error);
         }
-        if(isEncrypted) {
-            // decrypt the value
-            String selfEncryptionKey = keys.get(KeysUtil.selfEncryptionKeyName);
-            try {
-                value = EncryptionUtil.aesDecryptFromBase64(rawResponse.data, selfEncryptionKey);
-            } catch (NoSuchPaddingException | NoSuchAlgorithmException | InvalidAlgorithmParameterException | InvalidKeyException | IllegalBlockSizeException | BadPaddingException | NoSuchProviderException e) {
-                throw new AtException("Failed to " + command + " : " + e.getMessage(), e);
-            }
-        } else {
-            value = rawResponse.data;
+
+        // 2. decrypt the value
+        String selfEncryptionKey = keys.get(KeysUtil.selfEncryptionKeyName);
+        try {
+            value = EncryptionUtil.aesDecryptFromBase64(rawResponse.data, selfEncryptionKey);
+        } catch (NoSuchPaddingException | NoSuchAlgorithmException | InvalidAlgorithmParameterException | InvalidKeyException | IllegalBlockSizeException | BadPaddingException | NoSuchProviderException e) {
+            throw new AtException("Failed to " + command + " : " + e.getMessage(), e);
         }
+
+        // 3. update metadata in key object
+        Metadata metadataRead;
+        LlookupVerbBuilder metaLlookup = new LlookupVerbBuilder();
+        metaLlookup.with(key, LlookupVerbBuilder.Type.METADATA);
+        String metaCommand = metaLlookup.build();
+        Secondary.Response metaResponse = secondary.executeCommand(metaCommand, false);
+        if (metaResponse.isError) {
+            throw new AtException("Failed to " + metaCommand + " : " + metaResponse.error);
+        }
+        try {
+            metadataRead = Metadata.fromString(metaResponse);
+        } catch (AtException e) {
+            throw new AtException("Failed to " + metaCommand + " : " + e.getMessage(), e);
+        }
+
+        key.metadata = Metadata.squash(key.metadata, metadataRead);        
+
         return value;
     }
+
     private String _put(SelfKey selfKey, String value) throws AtException {
         // sign dataSignature
         selfKey.metadata.dataSignature = generateSignature(value);
@@ -458,7 +466,9 @@ public class AtClientImpl implements AtClient {
         }
 
         // update secondary
-        String command = "update" + selfKey.metadata.toString() + ":" + selfKey.toString() + " " + cipherText;
+        UpdateVerbBuilder builder = new UpdateVerbBuilder();
+        builder.with(selfKey, cipherText);
+        String command = builder.build();
         Secondary.Response response = secondary.executeCommand(command, true);
         if(response.isError) {
             throw new AtException("Failed to update " + selfKey + " : " + response.error);
@@ -467,7 +477,9 @@ public class AtClientImpl implements AtClient {
     }
 
     private String _delete(SelfKey key) throws AtException {
-        String command = "delete:" + key.toString();
+        DeleteVerbBuilder builder = new DeleteVerbBuilder();
+        builder.with(key);
+        String command = builder.build();
         Secondary.Response response = secondary.executeCommand(command, true);
         if(response.isError) {
             throw new AtException("Failed to run command " + command + " : " + response.error);
@@ -476,42 +488,116 @@ public class AtClientImpl implements AtClient {
     }
 
     private String _get(PublicKey key) throws AtException {
-        // 2 scenarios
-        // 1. look in own secondary server (including cached)
-        // 2. look in another secondary server (via plookup)
+        String responseData;
 
-        Secondary.Response rawResponse = null;
+        String dataCommand; // to get data
+        String metaCommand; // to get metadata
 
-        // 1. look in own secondary
-        String command = "llookup:" + key.toString();
-        String metaCommand = "llookup:meta:" + key.toString();
-        rawResponse = secondary.executeCommand(command, false);
-        if(rawResponse.isError) {
-            // try cached
-            command = "llookup:cached:" + key.toString();
-            metaCommand = "llookup:meta:cached:" + key.toString();
-            rawResponse = secondary.executeCommand(command, false);
-            if(rawResponse.isError) {
-                // 2. try plookup
-                command = "plookup:" + key.toString().replace("public:", "");
-                metaCommand = "plookup:meta:" + key.toString().replace("public:", "");
-                rawResponse = secondary.executeCommand(command, false);
-                if(rawResponse.isError) {
-                    throw new AtException("Failed to " + command + " : " + rawResponse.error);
-                }
-            }
-        }
-        // low priority - update AtKey metadata with squash, if any error happens, then this is not a problem, just missing metadata
-        Secondary.Response rawResponseMeta = secondary.executeCommand(metaCommand, false);
-        if(!rawResponseMeta.isError) {
-            try {
-                key.metadata = Metadata.squash(key.metadata, Metadata.fromString(rawResponseMeta));
-            } catch (ParseException e) {
-                // ignore
-            }
+        // 1. generate command using verb builders
+        if(key.sharedBy.toString().equalsIgnoreCase(atSign.toString())) {
+            // local lookup
+            LlookupVerbBuilder dataBuilder = new LlookupVerbBuilder();
+            dataBuilder.with(key, LlookupVerbBuilder.Type.NONE);
+            dataCommand = dataBuilder.build();
+
+            LlookupVerbBuilder metaBuilder = new LlookupVerbBuilder();
+            metaBuilder.with(key, LlookupVerbBuilder.Type.METADATA);
+            metaCommand = metaBuilder.build();
+        } else {
+            // check if key is cached
+            LlookupVerbBuilder dataBuilder = new LlookupVerbBuilder();
+            dataBuilder.with(key, LlookupVerbBuilder.Type.NONE);
+            dataBuilder.setIsCached(true);
+            dataCommand = dataBuilder.build();
+
+            LlookupVerbBuilder metaBuilder = new LlookupVerbBuilder();
+            metaBuilder.with(key, LlookupVerbBuilder.Type.METADATA);
+            metaBuilder.setIsCached(true);
+            metaCommand = metaBuilder.build();
         }
 
-        return rawResponse.data;
+        // 2. get the data
+        // llookup:<fullKeyName> or llookup:cached:<key>
+        Secondary.Response dataResponse = secondary.executeCommand(dataCommand, false);
+        if(dataResponse.isError) {
+            // 2.A. if data is not found, plookup
+            PlookupVerbBuilder dataBuilder = new PlookupVerbBuilder();
+            dataBuilder.with(key, PlookupVerbBuilder.Type.NONE);
+            dataCommand = dataBuilder.build(); // plookup:<fullKeyName>
+            
+            PlookupVerbBuilder metaBuilder = new PlookupVerbBuilder();
+            metaBuilder.with(key, PlookupVerbBuilder.Type.METADATA);
+            metaCommand = metaBuilder.build(); // plookup:meta:<fullKeyName>
+            
+            dataResponse = secondary.executeCommand(dataCommand, false);
+            if(dataResponse.isError) {   
+                throw new AtException("Failed to run command " + dataCommand + " : " + dataResponse.error);
+            }
+
+        }
+
+        responseData = dataResponse.data;
+
+        // 3. get the metadata and update the key object
+        // llookup:<fullKeyName> or plookup:meta:<fullKeyName>
+        Secondary.Response metaResponse = secondary.executeCommand(metaCommand, false);
+        if(metaResponse.isError) {
+            throw new AtException("Failed to run command " + metaCommand + " : " + metaResponse.error);
+        }
+        key.metadata = Metadata.squash(key.metadata, Metadata.fromString(metaResponse)); // update object metadata
+
+        return responseData;
+
+        // =============== OLD ===============
+
+        // // 3 scenarios
+        // // 1. look in own secondary server (e.g. public:test@alice)
+        // // 2. look in own secondary server cached (e.g. cached:public:test@bob)
+        // // 3. look in another secondary server (via plookup) (e.g. public:test@bob -> plookup:test@bob)
+
+        // PlookupVerbBuilder builder = new PlookupVerbBuilder();
+        // PlookupVerbBuilder builderMeta = new PlookupVerbBuilder();
+
+        // String command = null; // data command
+        // String metaCommand = null; // metadata command
+        // Secondary.Response rawResponse = null;
+
+        // // 1. look in own secondary
+        // LlookupVerbBuilder builder1 = new LlookupVerbBuilder();
+        // builder1.with(key, LlookupVerbBuilder.Type.NONE);
+        // command = builder1.build();
+        // builder1.setType(LlookupVerbBuilder.Type.METADATA);
+        // metaCommand = builder1.build();
+        // builder1.setType(LlookupVerbBuilder.Type.NONE);
+        // rawResponse = secondary.executeCommand(command, false);
+        // if(rawResponse.isError) {
+        //     // 2. try cached
+        //     builder1.setIsCached(true);
+        //     command = builder1.build();
+        //     builder1.setType(LlookupVerbBuilder.Type.METADATA);
+        //     metaCommand = builder1.build();
+        //     rawResponse = secondary.executeCommand(command, false);
+        //     if(rawResponse.isError) {
+        //         // 3. try plookup
+        //         String withoutPublic = key.toString().replace("public:", "");
+        //         PlookupVerbBuilder pBuilder1 = new PlookupVerbBuilder();
+        //         pBuilder1.with(key, PlookupVerbBuilder.Type.NONE);
+        //         command = pBuilder1.build();
+        //         pBuilder1.setType(PlookupVerbBuilder.Type.METADATA);
+        //         metaCommand = pBuilder1.build();
+        //         rawResponse = secondary.executeCommand(command, false);
+        //         if(rawResponse.isError) {
+        //             throw new AtException("Failed to " + command + " : " + rawResponse.error);
+        //         }
+        //     }
+        // }
+
+        // Secondary.Response rawResponseMeta = secondary.executeCommand(metaCommand, false);
+        // if(!rawResponseMeta.isError) {
+        //     key.metadata = Metadata.squash(key.metadata, Metadata.fromString(rawResponseMeta));
+        // }
+
+        // return rawResponse.data;
     }
 
     private String _put(PublicKey publicKey, String value) throws AtException {
@@ -519,7 +605,12 @@ public class AtClientImpl implements AtClient {
         publicKey.metadata.dataSignature = generateSignature(value);
 
         // update
-        String command = "update" + publicKey.metadata.toString() + ":" + publicKey.toString() + " " + value;
+        UpdateVerbBuilder builder = new UpdateVerbBuilder();
+        builder.with(publicKey, value);
+        
+        // String command = "update" + publicKey.metadata.toString() + ":" + publicKey.toString() + " " + value;
+        String command = builder.build();
+
         Secondary.Response rawResponse = secondary.executeCommand(command, false);
         if(rawResponse.isError) {
             throw new AtException(rawResponse.error);
@@ -528,7 +619,9 @@ public class AtClientImpl implements AtClient {
     }
 
     private String _delete(PublicKey key) throws AtException {
-        String command = "delete:" + key.toString();
+        DeleteVerbBuilder builder = new DeleteVerbBuilder();
+        builder.with(key);
+        String command = builder.build();
         Secondary.Response rawResponse = secondary.executeCommand(command, false);
         if(rawResponse.isError) {
             throw new AtException(rawResponse.error);
@@ -545,7 +638,11 @@ public class AtClientImpl implements AtClient {
     private String _put(PublicKey publicKey, byte[] value) throws AtException {throw new RuntimeException("Not Implemented");}
 
     private List<AtKey> _getAtKeys(String regex) throws AtException, ParseException {
-        Response scanRawResponse = executeCommand("scan " + regex, false);
+        ScanVerbBuilder scanVerbBuilder = new ScanVerbBuilder();
+        scanVerbBuilder.setRegex(regex);
+        scanVerbBuilder.setShowHidden(true); 
+        String command = scanVerbBuilder.build();
+        Response scanRawResponse = executeCommand(command, false);
         ResponseTransformers.ScanResponseTransformer scanResponseTransformer = new ResponseTransformers.ScanResponseTransformer();
         List<String> rawArray = scanResponseTransformer.transform(scanRawResponse);
         List<AtKey> atKeys = new ArrayList<>();

--- a/at_client/src/main/java/org/atsign/common/AtSign.java
+++ b/at_client/src/main/java/org/atsign/common/AtSign.java
@@ -5,12 +5,8 @@ public class AtSign {
     private final String withoutPrefix;
 
     public AtSign(String atSign) {
-        atSign = atSign.trim();
-        if (! atSign.startsWith("@")) {
-            atSign = "@" + atSign;
-        }
-        this.atSign = atSign;
-        this.withoutPrefix = atSign.substring(1);
+        this.atSign = formatAtSign(atSign);
+        this.withoutPrefix = this.atSign.substring(1);
     }
 
     public String withoutPrefix() { return withoutPrefix; }
@@ -34,4 +30,18 @@ public class AtSign {
     public int hashCode() {
         return atSign.hashCode();
     }
+
+    /**
+     * Returns a formatted atSign
+     * @param atSignStr e.g. "@bob"
+     * @return formatted atSign (e.g. "alice " --> "@alice")
+     */
+    public static String formatAtSign(String atSignStr) {
+        atSignStr = atSignStr.trim();
+        if (!atSignStr.startsWith("@")) {
+            atSignStr = "@" + atSignStr;
+        }
+        return atSignStr;
+    }
+    
 }

--- a/at_client/src/main/java/org/atsign/common/Keys.java
+++ b/at_client/src/main/java/org/atsign/common/Keys.java
@@ -350,6 +350,11 @@ public abstract class Keys {
         atKey.metadata = Metadata.squash(atKey.metadata, Metadata.fromString(llookedUpMetadata));
         return atKey;
     }
+
+    public static AtKey fromString(Secondary.Response lookupAllResponse) throws AtException {
+        // TODO once transformers are done
+        return null;
+    }
 }
 
 //        static AtKey fromString(String key) {

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -299,6 +299,57 @@ public class VerbBuilders {
 
 	}
 
+	public static class LookupVerbBuilder implements VerbBuilder {
+		
+		// look up a key shared with you in another atSign's secondary
+		// the sender atSign (other person) is the sharedBy atSign, while you are the sharedWith atSign.
+		
+		// Type of Lookup
+		public enum Type {
+			NONE, // lookup:<fullKeyName>
+			METADATA, // lookup:meta:<fullKeyName>
+			ALL, // lookup:all:<fullKeyName>
+		}
+		
+		private String key; // key name e.g. "test", "location", "email" [required]
+		private String sharedWith; // sharedBy atSign e.g. "@alice" [required] (not your atSign, the atSign of another secondary, get)
+
+		private Type type = Type.NONE;
+		
+		public void setKeyName(String key) {
+			this.key = key;
+		}
+
+		public void setSharedWith(String sharedWith) {
+			this.sharedWith = sharedWith;
+		}
+
+		public void setType(Type type) {
+			this.type = type;
+		}
+		
+		@Override
+		public String build() {
+			if(key == null || key.isEmpty() || sharedWith == null || sharedWith.isEmpty()) {
+				throw new IllegalArgumentException("keyName and sharedWith cannot be null or empty");
+			}
+			String s = "lookup:";
+			switch (type) {
+				case METADATA:
+					s += "meta:";
+					break;
+				case ALL:
+					s += "all:";
+					break;
+				default:
+					break;
+			}
+			s += this.key;
+			s += AtSign.formatAtSign(this.sharedWith);
+			return s; // eg: "lookup:meta:test@bob"
+		}
+	}
+
 	public static class ScanVerbBuilder implements VerbBuilder {
 		
 		// Regex to filter the keys

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -77,6 +77,147 @@ public class VerbBuilders {
 
 	}
 
+	public static class UpdateVerbBuilder implements VerbBuilder {
+
+		/// Update the value (and metadata optionally) of a key.
+
+		// =======================================
+		// AtKey name details
+		// =======================================
+		private String key; // e.g. "test", "location", "email" [required]
+		private String sharedBy; // e.g. "@alice" [required]
+		private String sharedWith = ""; // e.g. "@bob" 
+		private Boolean isHidden = false; // if true, adds _ at the beginning of the fullKeyName
+		private Boolean isPublic = false; //   /// if [isPublic] is true, then [atKey] is accessible by all atSigns, if [isPublic] is false, then [atKey] is accessible either by [sharedWith] or [sharedBy]
+		private Boolean isCached = false; // if true, will add "cached:" to the fullKeyName
+		private Integer ttl = 0; // time to live in milliseconds (how long AtKey will exist)
+		private Integer ttb = 0; // time to birth in milliseconds (how long it will take for AtKey to exist)
+		private Integer ttr = null; // time to refresh in milliseconds (how long it will take for AtKey to refresh)
+		private Boolean ccd = null; // if true, cached keys will be deleted if the original key is deleted
+		private boolean isBinary = false; // if true, the value contains binary data
+		private boolean isEncrypted = false; // if true, the value is encrypted with some encryption key
+		private String dataSignature = null; // usually public data is signed with the private key to prove that the data is authentic
+		private String sharedKeyEnc = null; // will be set only when [sharedWith] is set. Will be encrypted using the public key of [sharedWith] atsign
+		private String pubKeyCS = null; // checksum of the public of of [sharedWith] atSign. Will be set only when [sharedWith] is set.
+		private String encoding = null; // indicates if public data is encoded. If the public data contains a new line character, the data will be encoded and the encoding will be set to given type of encoding
+
+		private Object value; // the value to set [required]
+
+		public void setKeyName(String keyName) {
+			this.key = keyName;
+		}
+
+		public void setSharedBy(String sharedBy) {
+			this.sharedBy = sharedBy;
+		}
+
+		public void setSharedWith(String sharedWith) {
+			this.sharedWith = sharedWith;
+		}
+
+		public void setIsHidden(Boolean isHidden) {
+			this.isHidden = isHidden;
+		}
+
+		public void setIsPublic(Boolean isPublic) {
+			this.isPublic = isPublic;
+		}
+
+		public void setIsCached(Boolean isCached) {
+			this.isCached = isCached;
+		}
+
+		public void setTtl(Integer ttl) {
+			this.ttl = ttl;
+		}
+
+		public void setTtb(Integer ttb) {
+			this.ttb = ttb;
+		}
+
+		public void setTtr(Integer ttr) {
+			this.ttr = ttr;
+		}
+
+		public void setCcd(Boolean ccd) {
+			this.ccd = ccd;
+		}
+
+		public void setIsBinary(boolean isBinary) {
+			this.isBinary = isBinary;
+		}
+
+		public void setIsEncrypted(boolean isEncrypted) {
+			this.isEncrypted = isEncrypted;
+		}
+
+		public void setDataSignature(String dataSignature) {
+			this.dataSignature = dataSignature;
+		}
+
+		public void setSharedKeyEnc(String sharedKeyEnc) {
+			this.sharedKeyEnc = sharedKeyEnc;
+		}
+
+		public void setPubKeyCS(String pubKeyCS) {
+			this.pubKeyCS = pubKeyCS;
+		}
+
+		public void setEncoding(String encoding) {
+			this.encoding = encoding;
+		}
+
+		public void setValue(Object value) {
+			this.value = value;
+		}
+
+		@Override
+		public String build() {
+			if(key == null || key.isEmpty() || sharedBy == null || sharedBy.isEmpty() || value == null || value.toString().isEmpty()) {
+				throw new IllegalArgumentException("keyName, sharedBy, and value cannot be null or empty");
+			}
+			String fullKeyName = buildAtKeyStr();
+			String metadata = buildMetadataStr();
+			String s = "update:" + metadata + ":" + fullKeyName + " " + value.toString();
+			return s;
+		}
+
+		private String buildAtKeyStr() {
+			String s = "";
+			if(isHidden) {
+				s += "_";
+			}
+			if(isCached) {
+				s += "cached:";
+			}
+			if(isPublic) {
+				s += "public:";
+			}
+			if(sharedWith != null) {
+				s += AtSign.formatAtSign(sharedWith) + ":";
+			}
+			s += key;
+			s += AtSign.formatAtSign(sharedBy);
+			return s;
+		}
+
+		private String buildMetadataStr() {
+			Metadata metadata = new Metadata();
+			metadata.ttl = ttl;
+			metadata.ttb = ttb;
+			metadata.ttr = ttr;
+			metadata.ccd = ccd;
+			metadata.isBinary = isBinary;
+			metadata.isEncrypted = isEncrypted;
+			metadata.dataSignature = dataSignature;
+			metadata.sharedKeyEnc = sharedKeyEnc;
+			metadata.pubKeyCS = pubKeyCS;
+			// metadata.encoding = encoding;
+			return metadata.toString();
+		}
+		
+	}
+
 	public static class ScanVerbBuilder implements VerbBuilder {
 		
 		// Regex to filter the keys

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -293,6 +293,16 @@ public class VerbBuilders {
 			this.type = type;
 		}
 
+		public void with(AtKey atKey, LlookupVerbBuilder.Type type) {
+			setKeyName(atKey.name);
+			setSharedBy(atKey.sharedBy.toString());
+			if(atKey.sharedWith != null && !atKey.sharedWith.toString().isEmpty()) setSharedWith(atKey.sharedWith.toString());
+			setIsHidden(atKey.metadata.isHidden);
+			setIsPublic(atKey.metadata.isPublic);
+			setIsCached(atKey.metadata.isCached);
+			setType(type);
+		}
+
 		@Override
 		public String build() {
 			if(key == null || key.isEmpty() || sharedBy == null || sharedBy.isEmpty()) {

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -59,6 +59,24 @@ public class VerbBuilders {
 		}
 	}
 
+	public static class PKAMVerbBuilder implements VerbBuilder {
+		
+		// public key authentication method
+
+		private String digest; // digest the challenge string given by the from verb [required]
+
+		public void setDigest(String digest) {
+			this.digest = digest;
+		}
+
+		@Override
+		public String build() {
+			String s = "pkam:" + digest;
+			return s;
+		}
+
+	}
+
 	public static class ScanVerbBuilder implements VerbBuilder {
 		
 		// Regex to filter the keys

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -350,6 +350,69 @@ public class VerbBuilders {
 		}
 	}
 
+	public static class PlookupVerbBuilder implements VerbBuilder {
+
+		// look up a public key in another atSign's secondary
+		// e.g. "plookup:publickey@bob" will return the data of the key "public:publickey@bob" in @bob's secondary server (you are @alice, @bob is not you)
+		
+		// Type of plookup
+		public enum Type {
+			NONE, // just get the data
+			METADATA, // get the metadata but no data (plookup:meta:)
+			ALL, // get the data and metadata (plookup:all:)
+		}
+		
+		// AtKey details
+		private String key; // key name (e.g. location, test) [required]
+		private String sharedBy; // sharedBy atSign ("@bob") [required]
+
+		private Boolean isCached = false; // if true, will add "cached:" to the fullKeyName
+
+		private Type type = Type.NONE;
+
+		public void setKeyName(String key) {
+			this.key = key;
+		}
+
+		public void setSharedBy(String sharedBy) {
+			this.sharedBy = sharedBy;
+		}
+
+		public void setIsCached(Boolean isCached) {
+			this.isCached = isCached;
+		}
+
+		public void setType(Type type) {
+			this.type = type;
+		}
+
+		@Override
+		public String build() {
+			if(this.key == null || this.sharedBy == null) {
+				throw new IllegalArgumentException("key or sharedBy is null");
+			}
+			String s = "plookup:";
+			switch(type) {
+				case METADATA:
+					s += "meta:";
+					break;
+				case ALL:
+					s += "all:";
+					break;
+				default:
+					break;
+			}
+			if(isCached) {
+				s += "cached:";
+			}
+			s += this.key;
+			s += AtSign.formatAtSign(this.sharedBy);
+
+			return s; // e.g: "plookup:meta:@alice:test@bob"
+		}
+
+	}
+
 	public static class ScanVerbBuilder implements VerbBuilder {
 		
 		// Regex to filter the keys

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -258,10 +258,10 @@ public class VerbBuilders {
 
 		private String key; // e.g. "test", "location", "email" [required]
 		private String sharedBy; // e.g. sharedBy atSign "@alice" [required]
-		private String sharedWith = ""; // e.g. sharedWith atSign "@bob"
-		private Boolean isHidden = false; // if true, adds _ at the beginning of the fullKeyName
-		private Boolean isPublic = false; // if [isPublic] is true, then [atKey] is accessible by all atSigns and "public:" will be added to the fullKeyName, if [isPublic] is false, then [atKey] is accessible either by [sharedWith] or [sharedBy]
-		private Boolean isCached = false; // if true, will add "cached:" to the fullKeyName
+		private String sharedWith = null; // e.g. sharedWith atSign "@bob"
+		private Boolean isHidden = null; // if true, adds _ at the beginning of the fullKeyName
+		private Boolean isPublic = null; // if [isPublic] is true, then [atKey] is accessible by all atSigns and "public:" will be added to the fullKeyName, if [isPublic] is false, then [atKey] is accessible either by [sharedWith] or [sharedBy]
+		private Boolean isCached = null; // if true, will add "cached:" to the fullKeyName
 
 		private Type type = Type.NONE;
 
@@ -309,13 +309,13 @@ public class VerbBuilders {
 				default:
 					break;
 			}
-			if(isHidden) {
+			if(isHidden != null && isHidden) {
 				s += "_";
 			}
-			if(isCached) {
+			if(isCached != null && isCached) {
 				s += "cached:";
 			}
-			if(isPublic) {
+			if(isPublic != null &&isPublic) {
 				s += "public:";
 			}
 			if(sharedWith != null && !sharedWith.isEmpty()) {

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -367,7 +367,7 @@ public class VerbBuilders {
 		public void setType(Type type) {
 			this.type = type;
 		}
-		
+
 		public void with(SharedKey sharedKey, LookupVerbBuilder.Type type) {
 			setKeyName(sharedKey.name);
 			setSharedWith(sharedKey.sharedWith.toString());
@@ -430,6 +430,12 @@ public class VerbBuilders {
 
 		public void setType(Type type) {
 			this.type = type;
+		}
+
+		public void with(PublicKey atKey, PlookupVerbBuilder.Type type) {
+			setKeyName(atKey.name);
+			setSharedBy(atKey.sharedBy.toString());
+			setType(type);
 		}
 
 		@Override

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -434,8 +434,8 @@ public class VerbBuilders {
 
 		@Override
 		public String build() {
-			if(this.key == null || this.sharedBy == null) {
-				throw new IllegalArgumentException("key or sharedBy is null");
+			if(this.key == null || this.key.isEmpty() || this.sharedBy == null || this.sharedBy.isEmpty()) {
+				throw new IllegalArgumentException("key or sharedBy is null or empty");
 			}
 			String s = "plookup:";
 			switch(type) {

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -31,6 +31,24 @@ public class VerbBuilders {
 			return "from:" + atSignStr;
 		}
 	}
+
+	public static class CRAMVerbBuilder implements VerbBuilder {
+
+		// chlallenge response authentication method
+
+		private String digest; // the digest to use for authentication, encrypt the challenge (given by the from verb) to get the digest [required]
+
+		public void setDigest(String digest) {
+			this.digest = digest;
+		}
+
+		@Override
+		public String build() {
+			String s = "cram:" + digest;
+			return s;
+		}
+	}
+
 	public static class ScanVerbBuilder implements VerbBuilder {
 		
 		// Regex to filter the keys

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -498,6 +498,15 @@ public class VerbBuilders {
 			this.isCached = isCached;
 		}
 
+		public void with(AtKey atKey) {
+			setKeyName(atKey.name);
+			setSharedBy(atKey.sharedBy.toString());
+			if(atKey.sharedWith != null && !atKey.sharedWith.toString().isEmpty()) setSharedWith(atKey.sharedWith.toString());
+			setIsHidden(atKey.metadata.isHidden);
+			setIsPublic(atKey.metadata.isPublic);
+			setIsCached(atKey.metadata.isCached);
+		}
+
 		@Override
 		public String build() {
 			if(key == null || sharedBy == null) {

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -189,6 +189,18 @@ public class VerbBuilders {
 			this.pubKeyCS = metadata.pubKeyCS;
 			this.encoding = metadata.encoding;
 		}
+
+		public void with(AtKey atKey, Object value) {
+			setKeyName(atKey.name);
+			setSharedBy(atKey.sharedBy.toString());
+			if(atKey.sharedWith != null && !atKey.sharedWith.toString().isEmpty()) setSharedWith(atKey.sharedWith.toString());
+			setIsCached(atKey.metadata.isCached);
+			setIsHidden(atKey.metadata.isHidden);
+			setIsPublic(atKey.metadata.isPublic);
+			setMetadata(atKey.metadata);
+			setValue(value);
+		}
+
 		@Override
 		public String build() {
 			if(key == null || key.isEmpty() || sharedBy == null || sharedBy.isEmpty() || value == null || value.toString().isEmpty()) {

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -9,12 +9,12 @@ import org.atsign.common.Keys.Metadata;
  *
  */
 public class VerbBuilders {
-	
+
 	public interface VerbBuilder {
 		/// Build the command to be sent to remote secondary for execution.
 		String build();
 	}
-	
+
 	public static class FromVerbBuilder implements VerbBuilder {
 		private String atSignStr; // the atSign that we are authenticating with (e.g. atSignStr.equals("@alice") <=> true) [required]
 
@@ -479,10 +479,10 @@ public class VerbBuilders {
 		
 		// Scans the keys shared by forAtSign
 		private String fromAtSign;
-		
+
 		// Scans for hidden keys (showHidden:true)
 		private boolean showHidden = false;
-		
+
 	    public void setRegex(String regex) {
 			this.regex = regex;
 		}

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -208,22 +208,22 @@ public class VerbBuilders {
 			}
 			String fullKeyName = buildAtKeyStr();
 			String metadata = buildMetadataStr();
-			String s = "update:" + metadata + ":" + fullKeyName + " " + value.toString();
+			String s = "update" + metadata + ":" + fullKeyName + " " + value.toString();
 			return s;
 		}
 
 		private String buildAtKeyStr() {
 			String s = "";
-			if(isHidden) {
+			if(isHidden != null && isHidden) {
 				s += "_";
 			}
-			if(isCached) {
+			if(isCached != null && isCached) {
 				s += "cached:";
 			}
-			if(isPublic) {
+			if(isPublic != null && isPublic) {
 				s += "public:";
 			}
-			if(sharedWith != null) {
+			if(sharedWith != null && !sharedWith.isEmpty()) {
 				s += AtSign.formatAtSign(sharedWith) + ":";
 			}
 			s += key;
@@ -242,7 +242,7 @@ public class VerbBuilders {
 			metadata.dataSignature = dataSignature;
 			metadata.sharedKeyEnc = sharedKeyEnc;
 			metadata.pubKeyCS = pubKeyCS;
-			// metadata.encoding = encoding;
+			metadata.encoding = encoding;
 			return metadata.toString();
 		}
 		

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -1,6 +1,7 @@
 package org.atsign.common;
 
 import org.apache.commons.lang3.StringUtils;
+import org.atsign.common.Keys.Metadata;
 
 /**
  * 
@@ -14,6 +15,22 @@ public class VerbBuilders {
 		String build();
 	}
 	
+	public static class FromVerbBuilder implements VerbBuilder {
+		private String atSignStr; // the atSign that we are authenticating with (e.g. atSignStr.equals("@alice") <=> true) [required]
+
+		public void setAtSign(String atSignStr) {
+			this.atSignStr = atSignStr;
+		}
+
+		@Override
+		public String build() {
+			atSignStr = AtSign.formatAtSign(atSignStr);
+			if(atSignStr == null || atSignStr.isEmpty()) {
+				throw new IllegalArgumentException("atSignStr cannot be null or empty");
+			}
+			return "from:" + atSignStr;
+		}
+	}
 	public static class ScanVerbBuilder implements VerbBuilder {
 		
 		// Regex to filter the keys

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -218,6 +218,87 @@ public class VerbBuilders {
 		
 	}
 
+	public static class LlookupVerbBuilder implements VerbBuilder {
+
+		public enum Type {
+			NONE, // llookup:<fullKeyName>
+			METADATA, // llookup:meta:<fullKeyName>
+			ALL, // llookup:all:<fullKeyName>
+		}
+
+		private String key; // e.g. "test", "location", "email" [required]
+		private String sharedBy; // e.g. sharedBy atSign "@alice" [required]
+		private String sharedWith = ""; // e.g. sharedWith atSign "@bob"
+		private Boolean isHidden = false; // if true, adds _ at the beginning of the fullKeyName
+		private Boolean isPublic = false; // if [isPublic] is true, then [atKey] is accessible by all atSigns and "public:" will be added to the fullKeyName, if [isPublic] is false, then [atKey] is accessible either by [sharedWith] or [sharedBy]
+		private Boolean isCached = false; // if true, will add "cached:" to the fullKeyName
+
+		private Type type = Type.NONE;
+
+		public void setKeyName(String key) {
+			this.key = key;
+		}
+
+		public void setSharedBy(String sharedBy) {
+			this.sharedBy = sharedBy;
+		}
+
+		public void setSharedWith(String sharedWith) {
+			this.sharedWith = sharedWith;
+		}
+
+		public void setIsHidden(Boolean isHidden) {
+			this.isHidden = isHidden;
+		}
+
+		public void setIsPublic(Boolean isPublic) {
+			this.isPublic = isPublic;
+		}
+
+		public void setIsCached(Boolean isCached) {
+			this.isCached = isCached;
+		}
+
+		public void setType(Type type) {
+			this.type = type;
+		}
+
+		@Override
+		public String build() {
+			if(key == null || key.isEmpty() || sharedBy == null || sharedBy.isEmpty()) {
+				throw new IllegalArgumentException("keyName and sharedBy cannot be null or empty");
+			}
+			String s = "llookup:";
+			switch (type) {
+				case METADATA:
+					s += "meta:";
+					break;
+				case ALL:
+					s += "all:";
+					break;
+				default:
+					break;
+			}
+			if(isHidden) {
+				s += "_";
+			}
+			if(isCached) {
+				s += "cached:";
+			}
+			if(isPublic) {
+				s += "public:";
+			}
+			if(sharedWith != null && !sharedWith.isEmpty()) {
+				s += AtSign.formatAtSign(sharedWith) + ":";
+			}
+			s += key;
+			s += AtSign.formatAtSign(sharedBy);
+			return s; // eg: "llookup:meta:cached:public:test@bob"
+			
+		}
+
+	}
+
 	public static class ScanVerbBuilder implements VerbBuilder {
 		
 		// Regex to filter the keys

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -368,6 +368,12 @@ public class VerbBuilders {
 			this.type = type;
 		}
 		
+		public void with(SharedKey sharedKey, LookupVerbBuilder.Type type) {
+			setKeyName(sharedKey.name);
+			setSharedWith(sharedKey.sharedWith.toString());
+			setType(type);
+		}
+		
 		@Override
 		public String build() {
 			if(key == null || key.isEmpty() || sharedWith == null || sharedWith.isEmpty()) {

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -1,7 +1,10 @@
 package org.atsign.common;
 
 import org.apache.commons.lang3.StringUtils;
+import org.atsign.common.Keys.AtKey;
 import org.atsign.common.Keys.Metadata;
+import org.atsign.common.Keys.PublicKey;
+import org.atsign.common.Keys.SharedKey;
 
 /**
  * 
@@ -86,16 +89,16 @@ public class VerbBuilders {
 		// =======================================
 		private String key; // e.g. "test", "location", "email" [required]
 		private String sharedBy; // e.g. "@alice" [required]
-		private String sharedWith = ""; // e.g. "@bob" 
-		private Boolean isHidden = false; // if true, adds _ at the beginning of the fullKeyName
-		private Boolean isPublic = false; //   /// if [isPublic] is true, then [atKey] is accessible by all atSigns, if [isPublic] is false, then [atKey] is accessible either by [sharedWith] or [sharedBy]
+		private String sharedWith = null; // e.g. "@bob" 
+		private Boolean isHidden = null; // if true, adds _ at the beginning of the fullKeyName
+		private Boolean isPublic = null; //   /// if [isPublic] is true, then [atKey] is accessible by all atSigns, if [isPublic] is false, then [atKey] is accessible either by [sharedWith] or [sharedBy]
 		private Boolean isCached = false; // if true, will add "cached:" to the fullKeyName
-		private Integer ttl = 0; // time to live in milliseconds (how long AtKey will exist)
-		private Integer ttb = 0; // time to birth in milliseconds (how long it will take for AtKey to exist)
+		private Integer ttl = null; // time to live in milliseconds (how long AtKey will exist) (0 by default)
+		private Integer ttb = null; // time to birth in milliseconds (how long it will take for AtKey to exist) (0 by default)
 		private Integer ttr = null; // time to refresh in milliseconds (how long it will take for AtKey to refresh)
 		private Boolean ccd = null; // if true, cached keys will be deleted if the original key is deleted
-		private boolean isBinary = false; // if true, the value contains binary data
-		private boolean isEncrypted = false; // if true, the value is encrypted with some encryption key
+		private Boolean isBinary = null; // if true, the value contains binary data
+		private Boolean isEncrypted = null; // if true, the value is encrypted with some encryption key
 		private String dataSignature = null; // usually public data is signed with the private key to prove that the data is authentic
 		private String sharedKeyEnc = null; // will be set only when [sharedWith] is set. Will be encrypted using the public key of [sharedWith] atsign
 		private String pubKeyCS = null; // checksum of the public of of [sharedWith] atSign. Will be set only when [sharedWith] is set.

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -413,6 +413,65 @@ public class VerbBuilders {
 
 	}
 
+	public static class DeleteVerbBuilder implements VerbBuilder {
+
+		private String key; // e.g. "test", "location", "email" [required]
+		private String sharedBy; // e.g. sharedBy atSign "@alice" [required]
+		private String sharedWith = ""; // e.g. sharedWith atSign "@bob"
+		private Boolean isHidden = false;
+		private Boolean isPublic = false; // if [isPublic] is true, then [atKey] is accessible by all atSigns and "public:" will be added to the fullKeyName, if [isPublic] is false, then [atKey] is accessible either by [sharedWith] or [sharedBy]
+		private Boolean isCached = false; // if true, will add "cached:" to the fullKeyName
+
+		public void setKeyName(String keyName) {
+			this.key = keyName;
+		}
+
+		public void setSharedBy(String sharedBy) {
+			this.sharedBy = sharedBy;
+		}
+
+		public void setSharedWith(String sharedWith) {
+			this.sharedWith = sharedWith;
+		}
+
+		public void setIsHidden(Boolean isHidden) {
+			this.isHidden = isHidden;
+		}
+
+		public void setIsPublic(Boolean isPublic) {
+			this.isPublic = isPublic;
+		}
+
+		public void setIsCached(Boolean isCached) {
+			this.isCached = isCached;
+		}
+
+		@Override
+		public String build() {
+			if(key == null || sharedBy == null) {
+				throw new IllegalArgumentException("key or sharedBy is null. These are required fields");
+			}
+
+			String s = "delete:";
+			if(isHidden) {
+				s += "_";
+			}
+			if(isCached) {
+				s += "cached:";
+			}
+			if(isPublic) {
+				s += "public:";
+			}
+			if(sharedWith != null && !sharedWith.isEmpty()) {
+				s += AtSign.formatAtSign(sharedWith) + ":";
+			}
+			s += key;
+			s += AtSign.formatAtSign(sharedBy);
+			return s; // eg: "delete:cached:public:test@bob"
+		}
+
+	}
+
 	public static class ScanVerbBuilder implements VerbBuilder {
 		
 		// Regex to filter the keys

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -49,6 +49,16 @@ public class VerbBuilders {
 		}
 	}
 
+	public static class POLVerbBuilder implements VerbBuilder {
+
+		// proof of life
+
+		@Override
+		public String build() {
+			return "pol";
+		}
+	}
+
 	public static class ScanVerbBuilder implements VerbBuilder {
 		
 		// Regex to filter the keys

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -174,6 +174,21 @@ public class VerbBuilders {
 			this.value = value;
 		}
 
+		public void setMetadata(Metadata metadata) {
+			this.isHidden = metadata.isHidden;
+			this.isPublic = metadata.isPublic;
+			this.isCached = metadata.isCached;
+			this.ttl = metadata.ttl;
+			this.ttb = metadata.ttb;
+			this.ttr = metadata.ttr;
+			this.ccd = metadata.ccd;
+			this.isBinary = metadata.isBinary;
+			this.isEncrypted = metadata.isEncrypted;
+			this.dataSignature = metadata.dataSignature;
+			this.sharedKeyEnc = metadata.sharedKeyEnc;
+			this.pubKeyCS = metadata.pubKeyCS;
+			this.encoding = metadata.encoding;
+		}
 		@Override
 		public String build() {
 			if(key == null || key.isEmpty() || sharedBy == null || sharedBy.isEmpty() || value == null || value.toString().isEmpty()) {

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -477,25 +477,33 @@ public class VerbBuilders {
 		// Regex to filter the keys
 		private String regex;
 		
-		// Scans the keys shared by <code>forAtSign</code>
+		// Scans the keys shared by forAtSign
 		private String fromAtSign;
 		
+		// Scans for hidden keys (showHidden:true)
+		private boolean showHidden = false;
 		
 	    public void setRegex(String regex) {
 			this.regex = regex;
 		}
 
-
 		public void setFromAtSign(String fromAtSign) {
 			this.fromAtSign = fromAtSign;
 		}
 
+		public void setShowHidden(boolean showHidden) {
+			this.showHidden = showHidden;
+		}
 
 		// r'^scan$|scan(:(?<forAtSign>@[^:@\s]+))?(:page:(?<page>\d+))?( (?<regex>\S+))?$';
 		public String build() {
 			
 			String command = "scan";
 			
+			if(showHidden) {
+				command += ":showHidden:true";
+			}
+
 			if(fromAtSign != null && !StringUtils.isBlank(fromAtSign)) {
 				command += ":" + fromAtSign;
 			}

--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -412,8 +412,6 @@ public class VerbBuilders {
 		private String key; // key name (e.g. location, test) [required]
 		private String sharedBy; // sharedBy atSign ("@bob") [required]
 
-		private Boolean isCached = false; // if true, will add "cached:" to the fullKeyName
-
 		private Type type = Type.NONE;
 
 		public void setKeyName(String key) {
@@ -422,10 +420,6 @@ public class VerbBuilders {
 
 		public void setSharedBy(String sharedBy) {
 			this.sharedBy = sharedBy;
-		}
-
-		public void setIsCached(Boolean isCached) {
-			this.isCached = isCached;
 		}
 
 		public void setType(Type type) {
@@ -453,9 +447,6 @@ public class VerbBuilders {
 					break;
 				default:
 					break;
-			}
-			if(isCached) {
-				s += "cached:";
 			}
 			s += this.key;
 			s += AtSign.formatAtSign(this.sharedBy);

--- a/at_client/src/test/java/org/atsign/common/FromStringTest.java
+++ b/at_client/src/test/java/org/atsign/common/FromStringTest.java
@@ -33,7 +33,7 @@ public class FromStringTest {
         try {
             Secondary.Response response = atClient.executeCommand("llookup:meta:" + KEY_NAME_STR, true);
             atKey = Keys.fromString(KEY_NAME_STR, response);
-        } catch (AtException | ParseException e) {
+        } catch (AtException e) {
             System.err.println(e);
             e.printStackTrace();
         }

--- a/at_client/src/test/java/org/atsign/common/FromStringTest.java
+++ b/at_client/src/test/java/org/atsign/common/FromStringTest.java
@@ -77,7 +77,7 @@ public class FromStringTest {
         AtKey atKey = null;
         try {
             atKey = Keys.fromString(KEY_NAME_STR, response);
-        } catch (AtException | ParseException e) {
+        } catch (AtException e) {
             System.err.println(e);
             e.printStackTrace();
         }

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -332,12 +332,40 @@ public class VerbBuildersTest {
 		command = scanVerbBuilder.build();
 		assertEquals("Scan from another @sign", "scan:@other", command);
 
-		// Test setting both regex and fromAtSign
+		// Test seting just showHidden
+		scanVerbBuilder = new ScanVerbBuilder();
+		scanVerbBuilder.setShowHidden(true);
+		command = scanVerbBuilder.build();
+		assertEquals("Scan with showHidden", "scan:showHidden:true", command);
+
+		// Test setting regex & fromAtSign
 		scanVerbBuilder = new ScanVerbBuilder();
 		scanVerbBuilder.setRegex("*.public");
 		scanVerbBuilder.setFromAtSign("@other");
 		command = scanVerbBuilder.build();
 		assertEquals("Scan with regex from another @sign", "scan:@other *.public", command);
+
+		// Test setting regex & showHidden
+		scanVerbBuilder = new ScanVerbBuilder();
+		scanVerbBuilder.setRegex("*.public");
+		scanVerbBuilder.setShowHidden(true);
+		command = scanVerbBuilder.build();
+		assertEquals("Scan with regex & showHidden", "scan:showHidden:true *.public", command);
+
+		// Test setting fromAtSign & showHidden
+		scanVerbBuilder = new ScanVerbBuilder();
+		scanVerbBuilder.setFromAtSign("@other");
+		scanVerbBuilder.setShowHidden(true);
+		command = scanVerbBuilder.build();
+		assertEquals("Scan with fromAtSign & showHidden", "scan:showHidden:true:@other", command);
+
+		// Test setting regex & fromAtSign & showHidden
+		scanVerbBuilder = new ScanVerbBuilder();
+		scanVerbBuilder.setRegex("*.public");
+		scanVerbBuilder.setFromAtSign("@other");
+		scanVerbBuilder.setShowHidden(true);
+		command = scanVerbBuilder.build();
+		assertEquals("Scan with regex, fromAtSign & showHidden", "scan:showHidden:true:@other *.public", command);
 	}
 
 	@Test

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -49,6 +49,16 @@ public class VerbBuildersTest {
 	}
 
 	@Test
+	public void polVerbBuilderTest() {
+		POLVerbBuilder builder;
+		String command;
+
+		builder = new POLVerbBuilder();
+		command = builder.build(); // "pol"
+		assertEquals("pol", command);
+	}
+
+	@Test
 	public void scanVerbBuilderTest() {
 
 		// Test not setting any parameters

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -356,9 +356,8 @@ public class VerbBuildersTest {
 		builder.setKeyName("publickey");
 		builder.setSharedBy("@alice");
 		builder.setType(PlookupVerbBuilder.Type.ALL);
-		builder.setIsCached(true);
-		command = builder.build(); // "plookup:cached:public:publickey@alice:all"
-		assertEquals("plookup:all:cached:publickey@alice", command);
+		command = builder.build(); // "plookup:all:publickey@alice"
+		assertEquals("plookup:all:publickey@alice", command);
 
 		// no key
 		assertThrows(IllegalArgumentException.class, () -> {
@@ -382,6 +381,13 @@ public class VerbBuildersTest {
 			b.setType(Type.ALL);
 			b.build();
 		});
+
+		// with
+		builder = new PlookupVerbBuilder();
+		PublicKey pk = new KeyBuilders.PublicKeyBuilder(new AtSign("@bob")).key("publickey").build();
+		builder.with(pk, Type.ALL);
+		command = builder.build(); // "plookup:all:publickey@bob"
+		assertEquals("plookup:all:publickey@bob", command);
 	}
 
 	@Test

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -322,6 +322,13 @@ public class VerbBuildersTest {
 			LookupVerbBuilder b = new LookupVerbBuilder();
 			b.build();
 		});
+
+		// with shared key
+		builder = new LookupVerbBuilder();
+		SharedKey sk = new KeyBuilders.SharedKeyBuilder(new AtSign("@sharedby"), new AtSign("@sharedwith")).key("test").build();
+		builder.with(sk, LookupVerbBuilder.Type.METADATA);
+		command = builder.build(); // "lookup:meta:test@sharedby"
+		assertEquals("lookup:meta:test@sharedwith", command);
 	}
 
 	@Test

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -184,6 +184,59 @@ public class VerbBuildersTest {
 	}
 
 	@Test
+	public void plookupVerbBuilderTest() {
+		PlookupVerbBuilder builder;
+		String command;
+
+		// Type.NONE
+		builder = new PlookupVerbBuilder();
+		builder.setKeyName("publickey");
+		builder.setSharedBy("@alice");
+		command = builder.build(); // "plookup:publickey@alice"
+		assertEquals("plookup:publickey@alice", command);
+
+		// Type.METADATA
+		builder = new PlookupVerbBuilder();
+		builder.setKeyName("publickey");
+		builder.setSharedBy("@alice");
+		builder.setType(PlookupVerbBuilder.Type.METADATA);
+		command = builder.build(); // "plookup:meta:publickey@alice"
+		assertEquals("plookup:meta:publickey@alice", command);
+
+		// Type.ALL
+		builder = new PlookupVerbBuilder();
+		builder.setKeyName("publickey");
+		builder.setSharedBy("@alice");
+		builder.setType(PlookupVerbBuilder.Type.ALL);
+		builder.setIsCached(true);
+		command = builder.build(); // "plookup:cached:public:publickey@alice:all"
+		assertEquals("plookup:all:cached:publickey@alice", command);
+
+		// no key
+		assertThrows(IllegalArgumentException.class, () -> {
+			PlookupVerbBuilder b = new PlookupVerbBuilder();
+			b.setSharedBy("@alice");
+			b.setType(Type.ALL);
+			b.build();
+		});
+
+		// no shared by
+		assertThrows(IllegalArgumentException.class, () -> {
+			PlookupVerbBuilder b = new PlookupVerbBuilder();
+			b.setKeyName("publickey");
+			b.setType(Type.ALL);
+			b.build();
+		});
+
+		// no key and no shared by
+		assertThrows(IllegalArgumentException.class, () -> {
+			PlookupVerbBuilder b = new PlookupVerbBuilder();
+			b.setType(Type.ALL);
+			b.build();
+		});
+	}
+
+	@Test
 	public void scanVerbBuilderTest() {
 
 		// Test not setting any parameters

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -3,10 +3,19 @@ package org.atsign.common;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import org.atsign.common.VerbBuilders.CRAMVerbBuilder;
+import org.atsign.common.VerbBuilders.DeleteVerbBuilder;
+import org.atsign.common.VerbBuilders.FromVerbBuilder;
+import org.atsign.common.VerbBuilders.LlookupVerbBuilder;
+import org.atsign.common.VerbBuilders.LookupVerbBuilder;
 import org.atsign.common.VerbBuilders.NotificationStatusVerbBuilder;
 import org.atsign.common.VerbBuilders.NotifyKeyChangeBuilder;
 import org.atsign.common.VerbBuilders.NotifyTextVerbBuilder;
+import org.atsign.common.VerbBuilders.PKAMVerbBuilder;
+import org.atsign.common.VerbBuilders.POLVerbBuilder;
+import org.atsign.common.VerbBuilders.PlookupVerbBuilder;
 import org.atsign.common.VerbBuilders.ScanVerbBuilder;
+import org.atsign.common.VerbBuilders.PlookupVerbBuilder.Type;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,6 +26,16 @@ public class VerbBuildersTest {
 	public void setUp() {
 	}
 
+	@Test
+	public void fromVerbBuilderTest() {
+		FromVerbBuilder builder;
+		String command;
+
+		builder = new FromVerbBuilder();
+		builder.setAtSign("@bob");
+		command = builder.build(); // "from:@bob"
+		assertEquals("from:@bob", command);
+	}
 	@Test
 	public void scanVerbBuilderTest() {
 

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -464,6 +464,27 @@ public class VerbBuildersTest {
 			DeleteVerbBuilder b = new DeleteVerbBuilder();
 			b.build();
 		});
+
+		// with self key
+		builder = new DeleteVerbBuilder();
+		SelfKey selfKey = new KeyBuilders.SelfKeyBuilder(new AtSign("@alice")).key("test").build();
+		builder.with(selfKey);
+		command = builder.build();
+		assertEquals("delete:test@alice", command);
+
+		// with public key
+		builder = new DeleteVerbBuilder();
+		PublicKey pk = new KeyBuilders.PublicKeyBuilder(new AtSign("@bob")).key("publickey").build();
+		builder.with(pk);
+		command = builder.build();
+
+		// with shared key
+		builder = new DeleteVerbBuilder();
+		SharedKey sk = new KeyBuilders.SharedKeyBuilder(new AtSign("@alice"), new AtSign("@bob")).key("test").build();
+		builder.with(sk);
+		command = builder.build();
+		assertEquals("delete:@bob:test@alice", command);
+
 	}
 
 	@Test

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -70,6 +70,94 @@ public class VerbBuildersTest {
 	}
 
 	@Test
+	public void updateVerbBuilderTest() {
+		UpdateVerbBuilder builder;
+		String command;
+
+		// self key
+		builder = new UpdateVerbBuilder();
+		builder.setKeyName("test");
+		builder.setSharedBy("@bob");
+		builder.setValue("my Value 123");
+		command = builder.build(); // "update:test@bob my Value 123"
+		assertEquals("update:test@bob my Value 123", command); 
+
+		// self key but shared with self
+		builder = new UpdateVerbBuilder();
+		builder.setKeyName("test");
+		builder.setSharedBy("@bob");
+		builder.setSharedWith("@bob");
+		builder.setValue("My value 123");
+		command = builder.build(); // "update:@alice:test@bob My value 123"
+		assertEquals("update:@bob:test@bob My value 123", command);
+
+		// public key
+		builder = new UpdateVerbBuilder();
+		builder.setKeyName("publickey");
+		builder.setSharedBy("@bob");
+		builder.setIsPublic(true);
+		builder.setValue("my Value 123");
+		command = builder.build(); // "update:public:publickey@bob my Value 123"
+		assertEquals("update:public:publickey@bob my Value 123", command);
+
+		// cached public key
+		builder = new UpdateVerbBuilder();
+		builder.setKeyName("publickey");
+		builder.setSharedBy("@alice");
+		builder.setIsPublic(true);
+		builder.setIsCached(true);
+		builder.setValue("my Value 123");
+		command = builder.build(); // "update:cached:public:publickey@alice my Value 123"
+		assertEquals("update:cached:public:publickey@alice my Value 123", command);
+
+		// shared key
+		builder = new UpdateVerbBuilder();
+		builder.setKeyName("sharedkey");
+		builder.setSharedBy("@bob");
+		builder.setSharedWith("@alice");
+		builder.setValue("my Value 123");
+		command = builder.build(); // "update:@alice:sharedkey@bob my Value 123"
+		assertEquals("update:@alice:sharedkey@bob my Value 123", command);
+
+		// with shared key
+		builder = new UpdateVerbBuilder();
+		SharedKey sk1 = new KeyBuilders.SharedKeyBuilder(new AtSign("@bob"), new AtSign("@alice")).key("test").build();
+		sk1.metadata.isBinary = true;
+		sk1.metadata.ttl = 1000*60*10; // 10 minutes
+		builder.with(sk1, "myBinaryValue123456");
+		command = builder.build(); // update:ttl:600000:isBinary:true:isEncrypted:true:@alice:test@bob myBinaryValue123456
+		assertEquals("update:ttl:600000:isBinary:true:isEncrypted:true:@alice:test@bob myBinaryValue123456", command);
+
+		// with public key
+		builder = new UpdateVerbBuilder();
+		PublicKey pk1 = new KeyBuilders.PublicKeyBuilder(new AtSign("@bob")).key("test").build();
+		pk1.metadata.isCached = true;
+		builder.with(pk1, "myValue123");
+		command = builder.build(); // update:cached:public:test@bob myValue123
+		assertEquals("update:isBinary:false:isEncrypted:false:cached:public:test@bob myValue123", command);
+
+		// with self key
+		builder = new UpdateVerbBuilder();
+		SelfKey sk2 = new KeyBuilders.SelfKeyBuilder(new AtSign("@bob")).key("test").build();
+		sk2.metadata.ttl = 1000*60*10; // 10 minutes
+		builder.with(sk2, "myValue123");
+		command = builder.build(); // update:ttl:600000:test@bob myValue123
+		assertEquals("update:ttl:600000:isBinary:false:isEncrypted:true:test@bob myValue123", command);
+
+		// with self key (shared with self)
+		builder = new UpdateVerbBuilder();
+		AtSign bob = new AtSign("@bob");
+		SelfKey sk3 = new KeyBuilders.SelfKeyBuilder(bob, bob).key("test").build();
+		sk3.metadata.ttl = 1000*60*10; // 10 minutes
+		builder.with(sk3, "myValue123");
+		command = builder.build(); // update:ttl:600000:@bob:test@bob myValue123
+		assertEquals("update:ttl:600000:isBinary:false:isEncrypted:true:@bob:test@bob myValue123", command);
+
+		// private hidden key
+		// TODO with private hidden key when implemented
+	}
+
+	@Test
 	public void llookupVerbBuilderTest() {
 		LlookupVerbBuilder builder;
 		String command;

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -237,6 +237,82 @@ public class VerbBuildersTest {
 	}
 
 	@Test
+	public void deleteVerbBuilderTest() {
+		DeleteVerbBuilder builder;
+		String command;
+
+		// delete a public key
+		builder = new DeleteVerbBuilder();
+		builder.setIsPublic(true);
+		builder.setKeyName("publickey");
+		builder.setSharedBy("@alice");
+		command = builder.build();
+		assertEquals("delete:public:publickey@alice", command);
+
+		// delete a cached public key
+		builder = new DeleteVerbBuilder();
+		builder.setIsCached(true);
+		builder.setIsPublic(true);
+		builder.setKeyName("publickey");
+		builder.setSharedBy("@bob");
+		command = builder.build();
+		assertEquals("delete:cached:public:publickey@bob", command);
+
+		// delete a self key
+		builder = new DeleteVerbBuilder();
+		builder.setKeyName("test");
+		builder.setSharedBy("@alice");
+		command = builder.build();
+		assertEquals("delete:test@alice", command);
+		
+		// delete a hidden self key
+		builder = new DeleteVerbBuilder();
+		builder.setIsHidden(true);
+		builder.setKeyName("test");
+		builder.setSharedBy("@alice");
+		command = builder.build();
+		assertEquals("delete:_test@alice", command);
+
+		// delete a shared key
+		builder = new DeleteVerbBuilder();
+		builder.setKeyName("test");
+		builder.setSharedBy("@alice");
+		builder.setSharedWith("@bob");
+		command = builder.build();
+		assertEquals("delete:@bob:test@alice", command);
+
+		// delete a cached shared key
+		builder = new DeleteVerbBuilder();
+		builder.setIsCached(true);
+		builder.setKeyName("test");
+		builder.setSharedBy("@alice");
+		builder.setSharedWith("@bob");
+		command = builder.build();
+		assertEquals("delete:cached:@bob:test@alice", command);
+
+		// missing key name
+		assertThrows(IllegalArgumentException.class, () -> {
+			DeleteVerbBuilder b = new DeleteVerbBuilder();
+			b.setSharedBy("@alice");
+			b.setSharedWith("@bob");
+			b.build();
+		});
+
+		// missing shared by
+		assertThrows(IllegalArgumentException.class, () -> {
+			DeleteVerbBuilder b = new DeleteVerbBuilder();
+			b.setKeyName("test");
+			b.build();
+		});
+
+		// missing key name and shared by
+		assertThrows(IllegalArgumentException.class, () -> {
+			DeleteVerbBuilder b = new DeleteVerbBuilder();
+			b.build();
+		});
+	}
+
+	@Test
 	public void scanVerbBuilderTest() {
 
 		// Test not setting any parameters

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -70,6 +70,69 @@ public class VerbBuildersTest {
 	}
 
 	@Test
+	public void llookupVerbBuilderTest() {
+		LlookupVerbBuilder builder;
+		String command;
+
+		// Type.NONE self key
+		builder = new LlookupVerbBuilder();
+		builder.setKeyName("test");
+		builder.setSharedBy("@alice");
+		command = builder.build(); // "llookup:test@alice"
+		assertEquals("llookup:test@alice", command);
+
+		// Type.METADATA self key
+		builder = new LlookupVerbBuilder();
+		builder.setKeyName("test");
+		builder.setSharedBy("@alice");
+		builder.setType(LlookupVerbBuilder.Type.METADATA);
+		command = builder.build(); // "llookup:meta:test@alice"
+		assertEquals("llookup:meta:test@alice", command);
+
+		// hidden self key, meta
+		builder = new LlookupVerbBuilder();
+		builder.setKeyName("test");
+		builder.setSharedBy("@alice");
+		builder.setType(LlookupVerbBuilder.Type.METADATA);
+		builder.setIsHidden(true);
+		command = builder.build(); // "llookup:meta:_test@alice"
+		assertEquals("llookup:meta:_test@alice", command);
+		
+		// Type.ALL public cached key
+		builder = new LlookupVerbBuilder();
+		builder.setKeyName("publickey");
+		builder.setSharedBy("@alice");
+		builder.setIsCached(true);
+		builder.setIsPublic(true);
+		builder.setType(LlookupVerbBuilder.Type.ALL);
+		command = builder.build(); // "llookup:cached:public:publickey@alice:all"
+		assertEquals("llookup:all:cached:public:publickey@alice", command);
+
+		// no key name
+		assertThrows(IllegalArgumentException.class, () -> {
+			LlookupVerbBuilder b = new LlookupVerbBuilder();
+			b = new LlookupVerbBuilder();
+			b.setSharedBy("@alice");
+			b.build();
+		});
+		
+		// no shared by
+		assertThrows(IllegalArgumentException.class, () -> {
+			LlookupVerbBuilder b = new LlookupVerbBuilder();
+			b = new LlookupVerbBuilder();
+			b.setKeyName("test");
+			b.build();
+		});
+
+		// no key name and no shared by
+		assertThrows(IllegalArgumentException.class, () -> {
+			LlookupVerbBuilder b = new LlookupVerbBuilder();
+			b.build();
+		});
+
+	}
+
+	@Test
 	public void scanVerbBuilderTest() {
 
 		// Test not setting any parameters

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -3,6 +3,9 @@ package org.atsign.common;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import org.atsign.common.Keys.PublicKey;
+import org.atsign.common.Keys.SelfKey;
+import org.atsign.common.Keys.SharedKey;
 import org.atsign.common.VerbBuilders.CRAMVerbBuilder;
 import org.atsign.common.VerbBuilders.DeleteVerbBuilder;
 import org.atsign.common.VerbBuilders.FromVerbBuilder;
@@ -15,6 +18,7 @@ import org.atsign.common.VerbBuilders.PKAMVerbBuilder;
 import org.atsign.common.VerbBuilders.POLVerbBuilder;
 import org.atsign.common.VerbBuilders.PlookupVerbBuilder;
 import org.atsign.common.VerbBuilders.ScanVerbBuilder;
+import org.atsign.common.VerbBuilders.UpdateVerbBuilder;
 import org.atsign.common.VerbBuilders.PlookupVerbBuilder.Type;
 import org.junit.After;
 import org.junit.Before;
@@ -217,6 +221,55 @@ public class VerbBuildersTest {
 			LlookupVerbBuilder b = new LlookupVerbBuilder();
 			b.build();
 		});
+
+		// with public key
+		builder = new LlookupVerbBuilder();
+		PublicKey pk = new KeyBuilders.PublicKeyBuilder(new AtSign("@bob")).key("publickey").build();
+		builder.with(pk, LlookupVerbBuilder.Type.METADATA);
+		command = builder.build(); // "llookup:meta:public:publickey@bob"
+		assertEquals("llookup:meta:public:publickey@bob", command);
+
+		// with shared key
+		builder = new LlookupVerbBuilder();
+		SharedKey sk = new KeyBuilders.SharedKeyBuilder(new AtSign("@bob"), new AtSign("@alice")).key("sharedkey").build();
+		builder.with(sk, LlookupVerbBuilder.Type.NONE);
+		command = builder.build(); // "llookup:@alice:sharedkey@bob"
+		assertEquals("llookup:@alice:sharedkey@bob", command);
+
+		// with self key
+		builder = new LlookupVerbBuilder();
+		SelfKey selfKey1 = new KeyBuilders.SelfKeyBuilder(new AtSign("@bob")).key("test").build();
+		builder.with(selfKey1, LlookupVerbBuilder.Type.ALL);
+		command = builder.build(); // "llookup:all:test@bob"
+		assertEquals("llookup:all:test@bob", command);
+
+		// with self key (shared with self)
+		builder = new LlookupVerbBuilder();
+		AtSign as = new AtSign("@bob");
+		SelfKey selfKey2 = new KeyBuilders.SelfKeyBuilder(as, as).key("test").build();
+		builder.with(selfKey2, LlookupVerbBuilder.Type.ALL);
+		command = builder.build(); // "llookup:all:@bob:test@bob"
+		assertEquals("llookup:all:@bob:test@bob", command);
+
+		
+		// with cached public key
+		builder = new LlookupVerbBuilder();
+		PublicKey pk2 = new KeyBuilders.PublicKeyBuilder(new AtSign("@bob")).key("publickey").build();
+		pk2.metadata.isCached = true;
+		builder.with(pk2, LlookupVerbBuilder.Type.ALL);
+		command = builder.build(); // "llookup:all:cached:public:publickey@bob"
+		assertEquals("llookup:all:cached:public:publickey@bob", command);
+		
+		// with cached shared key
+		builder = new LlookupVerbBuilder();
+		SharedKey sk2 = new KeyBuilders.SharedKeyBuilder(new AtSign("@bob"), new AtSign("@alice")).key("sharedkey").build();
+		sk2.metadata.isCached = true;
+		builder.with(sk2, LlookupVerbBuilder.Type.NONE);
+		command = builder.build(); // "llookup:cached:@alice:sharedkey@bob"
+		assertEquals("llookup:cached:@alice:sharedkey@bob", command);
+
+		// with private hidden key 
+		// TODO: not implemented yet
 
 	}
 

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -133,6 +133,57 @@ public class VerbBuildersTest {
 	}
 
 	@Test
+	public void lookupVerbBuilderTest() {
+		LookupVerbBuilder builder;
+		String command;
+
+		// Type.NONE
+		builder = new LookupVerbBuilder();
+		builder.setKeyName("test");
+		builder.setSharedWith("@alice");
+		command = builder.build(); // "lookup:test@alice"
+		assertEquals("lookup:test@alice", command);
+
+		// Type.METADATA
+		builder = new LookupVerbBuilder();
+		builder.setKeyName("test");
+		builder.setSharedWith("@alice");
+		builder.setType(LookupVerbBuilder.Type.METADATA);
+		command = builder.build(); // "lookup:meta:test@alice"
+		assertEquals("lookup:meta:test@alice", command);
+
+		// Type.ALL
+		builder = new LookupVerbBuilder();
+		builder.setKeyName("test");
+		builder.setSharedWith("@alice");
+		builder.setType(LookupVerbBuilder.Type.ALL);
+		command = builder.build(); // "lookup:test@alice"
+		assertEquals("lookup:all:test@alice", command);
+		
+		// no key name
+		assertThrows(IllegalArgumentException.class, () -> {
+			LookupVerbBuilder b = new LookupVerbBuilder();
+			b = new LookupVerbBuilder();
+			b.setSharedWith("@alice");
+			b.build();
+		});
+
+		// no sharedWith
+		assertThrows(IllegalArgumentException.class, () -> {
+			LookupVerbBuilder b = new LookupVerbBuilder();
+			b = new LookupVerbBuilder();
+			b.setKeyName("test");
+			b.build();
+		});
+
+		// no key name and no shared with
+		assertThrows(IllegalArgumentException.class, () -> {
+			LookupVerbBuilder b = new LookupVerbBuilder();
+			b.build();
+		});
+	}
+
+	@Test
 	public void scanVerbBuilderTest() {
 
 		// Test not setting any parameters

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -36,6 +36,18 @@ public class VerbBuildersTest {
 		command = builder.build(); // "from:@bob"
 		assertEquals("from:@bob", command);
 	}
+
+	@Test
+	public void cramVerbBuilderTest() {
+		CRAMVerbBuilder builder;
+		String command;
+
+		builder = new CRAMVerbBuilder();
+		builder.setDigest("digest");
+		command = builder.build(); // "cram:digest"
+		assertEquals("cram:digest", command);
+	}
+
 	@Test
 	public void scanVerbBuilderTest() {
 

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -59,6 +59,17 @@ public class VerbBuildersTest {
 	}
 
 	@Test
+	public void pkamVerbBuilderTest() {
+		PKAMVerbBuilder builder;
+		String command;
+
+		builder = new PKAMVerbBuilder();
+		builder.setDigest("digest");
+		command = builder.build(); // "pkam:digest"
+		assertEquals("pkam:digest", command);
+	}
+
+	@Test
 	public void scanVerbBuilderTest() {
 
 		// Test not setting any parameters


### PR DESCRIPTION
[obo @JeremyTubongbanua]

**- What I did**
feat: VerbBuilders to more easily construct AtProtocol commands 

- [x] from
- [x] cram
- [x] pol verb builder
- [x] pkam verb builder
- [x] update verb builder
- [x] llookup verb builder
- [x] lookup verb builder
- [x] plookup verb builder
- [x] delete verb builder
- [x] add `showHidden` to scan verb builder
- [x] update verb builder

# Tests
- [x] from verb builder tests
- [x] cram verb builder tests
- [x] pol verb builder tests
- [x] pkam verb builder tests
- [x] llookup verb builder test
- [x] lookup verb builder tests
- [x] plookup verb builder tests
- [x] delete verb builder tests
- [x] more scan verb builder tests
- [x] update verb builder tests

# AtSIgn Util Static Method

- [x] `AtSign.formatAtSign(String atSignStr)` --> formats an atSign by adding @ at the beginning if not already added and trimming trailing white space

**- How I did it**
# Implement VerbBuilders in `AtClientImpl.java`

## Public Keys
- [x] implement update verb builder for `_put(PublicKey)`
- [x] implement plookup verb builder and llookup verb builder for `_get(PublicKey)` 
- [x] implement delete verb builder for `_delete(PublicKey)`

## Self Keys
- [x] implement update verb builder for `_put(SelfKey)`
- [x] implement llookup verb builder for `_get(SelfKey)`
- [x] implement delete verb builder for `_delete(SelfKey)`

## Scan
- [x] Use `ScanVerbBuilder` in `_getAtKeys(String)`

**- How to verify it**
Tests pass. Additional tests will follow to increase test coverage.

**- Description for the changelog**
feat: VerbBuilders to more easily construct AtProtocol commands 
