### PR TITLE
fix: atKeys file not being generated

### DIFF
--- a/at_client/src/main/java/org/atsign/client/util/KeysUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/KeysUtil.java
@@ -1,11 +1,12 @@
 package org.atsign.client.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.atsign.common.AtSign;
-import org.atsign.common.AtException;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
+import org.atsign.common.AtException;
+import org.atsign.common.AtSign;
+
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -45,11 +46,11 @@ public class KeysUtil {
         encryptedKeys.put(encryptionPrivateKeyName, EncryptionUtil.aesEncryptToBase64(keys.get(encryptionPrivateKeyName), selfEncryptionKey));
 
         String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(encryptedKeys);
-        Files.write(file.toPath(), json.getBytes(StandardCharsets.UTF_8));
+        Files.writeString(file.toPath(), json);
     }
 
     private static File getKeysFile(AtSign atSign) {
-        return new File(System.getProperty("user.home") + "/.atsign/keys/" + atSign + "_key.atKeys");
+        return new File(System.getProperty("user.dir") + "/keys/" + atSign + "_key.atKeys");
     }
 
     public static Map<String, String> loadKeys(AtSign atSign) throws Exception {
@@ -59,7 +60,7 @@ public class KeysUtil {
             throw new AtException("loadKeys: No file at " + file.getAbsolutePath());
         }
 
-        String json = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+        String json = Files.readString(file.toPath());
         @SuppressWarnings("unchecked") Map<String, String> encryptedKeys = mapper.readValue(json, Map.class);
 
         // All the keys are encrypted with the AES self encryption key (which is left unencrypted)

--- a/at_client/src/main/java/org/atsign/client/util/KeysUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/KeysUtil.java
@@ -7,6 +7,7 @@ import org.atsign.common.AtSign;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -46,7 +47,7 @@ public class KeysUtil {
         encryptedKeys.put(encryptionPrivateKeyName, EncryptionUtil.aesEncryptToBase64(keys.get(encryptionPrivateKeyName), selfEncryptionKey));
 
         String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(encryptedKeys);
-        Files.writeString(file.toPath(), json);
+        Files.write(file.toPath(), json.getBytes(StandardCharsets.UTF_8));
     }
 
     private static File getKeysFile(AtSign atSign) {
@@ -60,7 +61,7 @@ public class KeysUtil {
             throw new AtException("loadKeys: No file at " + file.getAbsolutePath());
         }
 
-        String json = Files.readString(file.toPath());
+        String json = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
         @SuppressWarnings("unchecked") Map<String, String> encryptedKeys = mapper.readValue(json, Map.class);
 
         // All the keys are encrypted with the AES self encryption key (which is left unencrypted)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- solved a bug that was keeping Onboard CLI from creating an atKeys file 

**- How I did it**
- Resolving a Mismatch in directory and file creating. The directory being created was "user.dir/keys" but the file was trying to write into the directory "user.home/.atsign/keys". This was throwing a NoSuchFileException breaking the onboarding flow.

**- How to verify it**
- Onboarding now creates the atKeys file at the expected path.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->