### PR TITLE
feat: LlookupAllResponseTransformer

### DIFF
--- a/at_client/src/main/java/org/atsign/common/Keys.java
+++ b/at_client/src/main/java/org/atsign/common/Keys.java
@@ -9,6 +9,9 @@ import org.atsign.client.util.DateUtil;
 import org.atsign.client.util.KeyStringUtil;
 import org.atsign.client.util.KeyStringUtil.KeyType;
 import org.atsign.common.ResponseTransformers.LlookupMetadataResponseTransformer;
+import org.atsign.common.response_models.LlookupAllResponse;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @SuppressWarnings("unused")
 public abstract class Keys {
@@ -146,11 +149,15 @@ public abstract class Keys {
         public Integer ttb;
         public Integer ttr;
         public Boolean ccd;
+        public OffsetDateTime createdBy;
+        public OffsetDateTime updatedBy;
         public OffsetDateTime availableAt;
         public OffsetDateTime expiresAt;
         public OffsetDateTime refreshAt;
         public OffsetDateTime createdAt;
         public OffsetDateTime updatedAt;
+        public String status;
+        public Integer version;
         public String dataSignature;
         public String sharedKeyStatus;
         public Boolean isPublic = false;
@@ -212,6 +219,33 @@ public abstract class Keys {
             } catch (ParseException e) {
                 throw new AtException("Could not parse dates from metadata. DateUtil.parse(String) threw the ParseException: " + e.toString(), e);
             }
+            return metadata;
+        }
+
+        public static Metadata fromModel(LlookupAllResponse.Metadata modelMetadata) throws AtException {
+            Metadata metadata = new Metadata();
+            metadata.ttl = modelMetadata.ttl;
+            metadata.ttb = modelMetadata.ttb;
+            metadata.ttr = modelMetadata.ttr;
+            metadata.ccd = modelMetadata.ccd;
+            try {
+                metadata.createdBy = DateUtil.parse(modelMetadata.createdBy);
+                metadata.updatedBy = DateUtil.parse(modelMetadata.updatedBy);
+                metadata.availableAt = DateUtil.parse(modelMetadata.availableAt);
+                metadata.expiresAt = DateUtil.parse(modelMetadata.expiresAt);
+                metadata.refreshAt = DateUtil.parse(modelMetadata.refreshAt);
+                metadata.createdAt = DateUtil.parse(modelMetadata.createdAt);
+                metadata.updatedAt = DateUtil.parse(modelMetadata.updatedAt);
+            } catch (ParseException e) {
+                throw new AtException("Could not parse date from LlookupAllResponse.Metadata: " + e.toString());
+            }
+            metadata.status = modelMetadata.status;
+            metadata.version = modelMetadata.version;
+            metadata.dataSignature = modelMetadata.dataSignature;
+            metadata.isEncrypted = modelMetadata.isEncrypted;
+            metadata.isBinary = modelMetadata.isBinary;
+            metadata.sharedKeyEnc = modelMetadata.sharedKeyEnc;
+            metadata.pubKeyCS = modelMetadata.pubKeyCS;
             return metadata;
         }
 

--- a/at_client/src/main/java/org/atsign/common/ResponseTransformers.java
+++ b/at_client/src/main/java/org/atsign/common/ResponseTransformers.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.atsign.client.api.Secondary.Response;
+import org.atsign.common.response_models.LlookupAllResponse;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ResponseTransformers {
@@ -32,6 +34,25 @@ public class ResponseTransformers {
 			}
 		}
 
+	}
+
+	public static class LlookupAllResponseTransformer implements ResponseTransformer<Response, LlookupAllResponse> {
+		@Override
+		public LlookupAllResponse transform(Response value) {
+			if (value.data == null || value.data.isEmpty()) {
+				return null;
+			}
+
+			LlookupAllResponse model = null;
+			ObjectMapper mapper = new ObjectMapper();
+			try {
+				model = mapper.readValue(value.data, LlookupAllResponse.class);
+			} catch (JsonProcessingException e) {
+				System.err.println(e.toString());
+				e.printStackTrace();
+			}
+			return model;
+		}
 	}
 
 	public static class LlookupMetadataResponseTransformer implements ResponseTransformer<Response, Map<String, Object>> {

--- a/at_client/src/main/java/org/atsign/common/response_models/LlookupAllResponse.java
+++ b/at_client/src/main/java/org/atsign/common/response_models/LlookupAllResponse.java
@@ -1,0 +1,57 @@
+package org.atsign.common.response_models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LlookupAllResponse {
+    
+    @JsonProperty
+    public String key;
+
+    @JsonProperty
+    public String data;
+
+    @JsonProperty
+    public Metadata metaData;
+
+    public class Metadata {
+        @JsonProperty
+        public String createdBy;
+        @JsonProperty
+        public String updatedBy;
+        @JsonProperty
+        public String createdAt;
+        @JsonProperty
+        public String updatedAt;
+        @JsonProperty
+        public String availableAt;
+        @JsonProperty
+        public String expiresAt;
+        @JsonProperty
+        public String refreshAt;
+        @JsonProperty
+        public String status;
+        @JsonProperty
+        public Integer version;
+        @JsonProperty
+        public Integer ttl;
+        @JsonProperty
+        public Integer ttb;
+        @JsonProperty
+        public Integer ttr;
+        @JsonProperty
+        public Boolean ccd;
+        @JsonProperty
+        public Boolean isBinary;
+        @JsonProperty
+        public Boolean isEncrypted;
+        @JsonProperty
+        public String dataSignature;
+        @JsonProperty
+        public String sharedKeyEnc;
+        @JsonProperty
+        public String pubKeyCS;
+        @JsonProperty
+        public String encoding;
+    }
+
+}

--- a/at_client/src/test/java/org/atsign/common/ResponseTransformerTest.java
+++ b/at_client/src/test/java/org/atsign/common/ResponseTransformerTest.java
@@ -1,75 +1,110 @@
 package org.atsign.common;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import java.util.Map;
-
-import org.atsign.client.api.AtClient;
 import org.atsign.client.api.Secondary;
-import org.atsign.client.util.ArgsUtil;
-import org.atsign.common.ResponseTransformers.LlookupMetadataResponseTransformer;
+import org.atsign.common.ResponseTransformers.LlookupAllResponseTransformer;
+import org.atsign.common.response_models.LlookupAllResponse;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ResponseTransformerTest {
-
-    @Test
-    public void LlookupMetadataResponseTransformerTest() {
-        String LLOOKUP_META_STR = "{\"createdBy\":null,\"updatedBy\":null,\"createdAt\":\"2022-07-13 21:54:28.519Z\",\"updatedAt\":\"2022-07-13 21:54:28.519Z\",\"availableAt\":\"2022-07-13 21:54:28.519Z\",\"expiresAt\":null,\"refreshAt\":null,\"status\":\"active\",\"version\":0,\"ttl\":0,\"ttb\":0,\"ttr\":null,\"ccd\":null,\"isBinary\":false,\"isEncrypted\":false,\"dataSignature\":null,\"sharedKeyEnc\":null,\"pubKeyCS\":null}";
-
-        Secondary.Response response = new Secondary.Response();
-        response.data = LLOOKUP_META_STR;
-
-        LlookupMetadataResponseTransformer transformer = new LlookupMetadataResponseTransformer();
-        Map<String, Object> map = transformer.transform(response);
-
-        assertEquals(null, map.get("createdBy"));
-        assertEquals(null, map.get("updatedBy"));
-        assertEquals("2022-07-13 21:54:28.519Z", map.get("createdAt"));
-        assertEquals("2022-07-13 21:54:28.519Z", map.get("updatedAt"));
-        assertEquals("2022-07-13 21:54:28.519Z", map.get("availableAt"));
-        assertEquals(null, map.get("expiresAt"));
-        assertEquals(null, map.get("refreshAt"));
-        assertEquals("active", map.get("status"));
-        assertEquals(0, map.get("version"));
-        assertEquals(0, map.get("ttl"));
-        assertEquals(0, map.get("ttb"));
-        assertEquals(null, map.get("ttr"));
-        assertEquals(null, map.get("ccd"));
-        assertEquals(false, map.get("isBinary"));
-        assertEquals(false, map.get("isEncrypted"));
-        assertEquals(null, map.get("dataSignature"));
-        assertEquals(null, map.get("sharedKeyEnc"));
-        assertEquals(null, map.get("pubKeyCS"));
+    
+    @Before
+    public void setUp() {
     }
 
     @Test
-    public void LlookupMetadataResponseTransformerTest2() {
-        String LLOOKUP_META_STR = "{\"createdBy\":null,\"updatedBy\":null,\"createdAt\":\"2022-07-27 22:12:58.077Z\",\"updatedAt\":\"2022-07-27 22:12:58.077Z\",\"availableAt\":\"2022-07-27 22:12:58.077Z\",\"expiresAt\":\"2022-07-27 22:42:58.077Z\",\"refreshAt\":null,\"status\":\"active\",\"version\":0,\"ttl\":1800000,\"ttb\":0,\"ttr\":null,\"ccd\":null,\"isBinary\":false,\"isEncrypted\":true,\"dataSignature\":\"oIq0kHvwQieVrhOs4dJLN61qNP73bNLLNPTRW7tAdapIZF3kSMrNVCcTAWWWyzb2Tyii51uZ7zlIYmHWuS4tIE0lMzrUeXGcfQhOrdjkrxf4qEceNR1qLa7tDjOAb8xuhf/zJ3yaen8NGswfKWwQluga/52SchFClrR99xEI93s=\",\"sharedKeyEnc\":null,\"pubKeyCS\":null}";
+    public void scanResponseTransformerTest() {
 
+    }
+
+    @Test
+    public void llookupAllResponseTransformerTest() {
+        String RESPONSE_STR = "{" +
+            "\"key\":\"public:publickey@cooking2\"," + 
+            "\"data\":\"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCz9nTBDDLxLgSxYu4+mDF3anWuTlKysXBBLsp3glrBP9xEXDx4muOHuHZIzuNvFlsjcCDF/mLSAJcvbxUoTsOQp+QD5XMhlNS9TWGsmNks7KHylNEhcqo2Va7RZxNS6MZBRacl+OusnebVKdOXDnbuevoED5fSklOz7mvdm9Mb2wIDAQAB\"," +
+            "\"metaData\":{" + 
+                    "\"createdBy\":null," +
+                    "\"updatedBy\":null," + 
+                    "\"createdAt\":\"2022-08-12 01:50:15.398Z\"," +
+                    "\"updatedAt\":\"2022-08-12 01:50:15.398Z\"," +
+                    "\"availableAt\":\"2022-08-12 01:50:15.398Z\"," +
+                    "\"expiresAt\":null," +
+                    "\"refreshAt\":null," +
+                    "\"status\":\"active\"," +
+                    "\"version\":0," +
+                    "\"ttl\":0," +
+                    "\"ttb\":0," +
+                    "\"ttr\":null," +
+                    "\"ccd\":null," +
+                    "\"isBinary\":false," +
+                    "\"isEncrypted\":false," +
+                    "\"dataSignature\":null," +
+                    "\"sharedKeyEnc\":null," +
+                    "\"pubKeyCS\":null," +
+                    "\"encoding\":null" + 
+                "}" + 
+            "}";
+
+        // System.out.println(RESPONSE_STR); //{"key":"public:publickey@cooking2","data":"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCz9nTBDDLxLgSxYu4+mDF3anWuTlKysXBBLsp3glrBP9xEXDx4muOHuHZIzuNvFlsjcCDF/mLSAJcvbxUoTsOQp+QD5XMhlNS9TWGsmNks7KHylNEhcqo2Va7RZxNS6MZBRacl+OusnebVKdOXDnbuevoED5fSklOz7mvdm9Mb2wIDAQAB","metaData":{"createdBy":null,"updatedBy":null,"createdAt":"2022-08-12 01:50:15.398Z","updatedAt":"2022-08-12 01:50:15.398Z","availableAt":"2022-08-12 01:50:15.398Z","expiresAt":null,"refreshAt":null,"status":"active","version":0,"ttl":0,"ttb":0,"ttr":null,"ccd":null,"isBinary":false,"isEncrypted":false,"dataSignature":null,"sharedKeyEnc":null,"pubKeyCS":null,"encoding":null}}
         Secondary.Response response = new Secondary.Response();
-        response.data = LLOOKUP_META_STR;
+        response.isError = false;
+        response.data = RESPONSE_STR;
+        LlookupAllResponse model = null;
+        LlookupAllResponseTransformer transformer = new LlookupAllResponseTransformer();
+        model = transformer.transform(response);
 
-        LlookupMetadataResponseTransformer transformer = new LlookupMetadataResponseTransformer();
-        Map<String, Object> map = transformer.transform(response);
+        assertEquals("public:publickey@cooking2", model.key);
+        assertEquals("MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCz9nTBDDLxLgSxYu4+mDF3anWuTlKysXBBLsp3glrBP9xEXDx4muOHuHZIzuNvFlsjcCDF/mLSAJcvbxUoTsOQp+QD5XMhlNS9TWGsmNks7KHylNEhcqo2Va7RZxNS6MZBRacl+OusnebVKdOXDnbuevoED5fSklOz7mvdm9Mb2wIDAQAB", model.data);
+        assertEquals(null, model.metaData.createdBy);       
+        assertEquals(null, model.metaData.updatedBy);
+        assertEquals("2022-08-12 01:50:15.398Z", model.metaData.createdAt);
+        assertEquals("2022-08-12 01:50:15.398Z", model.metaData.updatedAt);
+        assertEquals("2022-08-12 01:50:15.398Z", model.metaData.availableAt);
+        assertEquals(null, model.metaData.expiresAt);
+        assertEquals(null, model.metaData.refreshAt);
+        assertEquals("active", model.metaData.status);
+        assertTrue(model.metaData.version == 0);
+        assertTrue(model.metaData.ttl == 0);
+        assertTrue(model.metaData.ttb == 0);
+        assertEquals(null, model.metaData.ttr);
+        assertEquals(null, model.metaData.ccd);
+        assertEquals(false, model.metaData.isBinary);
+        assertEquals(false, model.metaData.isEncrypted);
+        assertEquals(null, model.metaData.dataSignature);
+        assertEquals(null, model.metaData.sharedKeyEnc);
+        assertEquals(null, model.metaData.pubKeyCS);
+        assertEquals(null, model.metaData.encoding);
+        
+        // System.out.println("FullKeyName: " + model.key);
+        // System.out.println("Data: " + model.data);
+        // System.out.println("MetaData.createdBy: " + model.metaData.createdBy);
+        // System.out.println("MetaData.updatedBy: " + model.metaData.updatedBy);
+        // System.out.println("MetaData.createdAt: " + model.metaData.createdAt);
+        // System.out.println("MetaData.updatedAt: " + model.metaData.updatedAt);
+        // System.out.println("MetaData.availableAt: " + model.metaData.availableAt);
+        // System.out.println("MetaData.expiresAt: " + model.metaData.expiresAt);
+        // System.out.println("MetaData.refreshAt: " + model.metaData.refreshAt);
+        // System.out.println("MetaData.status: " + model.metaData.status);
+        // System.out.println("MetaData.version: " + model.metaData.version);
+        // System.out.println("MetaData.ttl: " + model.metaData.ttl);
+        // System.out.println("MetaData.ttb: " + model.metaData.ttb);
+        // System.out.println("MetaData.ttr: " + model.metaData.ttr);
+        // System.out.println("MetaData.ccd: " + model.metaData.ccd);
+        // System.out.println("MetaData.isBinary: " + model.metaData.isBinary);
+        // System.out.println("MetaData.isEncrypted: " + model.metaData.isEncrypted);
+        // System.out.println("MetaData.dataSignature: " + model.metaData.dataSignature);
+        // System.out.println("MetaData.sharedKeyEnc: " + model.metaData.sharedKeyEnc);
+        // System.out.println("MetaData.pubKeyCS: " + model.metaData.pubKeyCS);
+        // System.out.println("MetaData.encoding: " + model.metaData.encoding);
 
-        assertEquals(null, map.get("createdBy"));
-        assertEquals(null, map.get("updatedBy"));
-        assertEquals("2022-07-27 22:12:58.077Z", map.get("createdAt"));
-        assertEquals("2022-07-27 22:12:58.077Z", map.get("updatedAt"));
-        assertEquals("2022-07-27 22:12:58.077Z", map.get("availableAt"));
-        assertEquals("2022-07-27 22:42:58.077Z", map.get("expiresAt"));
-        assertEquals(null, map.get("refreshAt"));
-        assertEquals("active", map.get("status"));
-        assertEquals(0, map.get("version"));
-        assertEquals(1800000, map.get("ttl"));
-        assertEquals(0, map.get("ttb"));
-        assertEquals(null, map.get("ttr"));
-        assertEquals(null, map.get("ccd"));
-        assertEquals(false, map.get("isBinary"));
-        assertEquals(true, map.get("isEncrypted"));
-        assertEquals("oIq0kHvwQieVrhOs4dJLN61qNP73bNLLNPTRW7tAdapIZF3kSMrNVCcTAWWWyzb2Tyii51uZ7zlIYmHWuS4tIE0lMzrUeXGcfQhOrdjkrxf4qEceNR1qLa7tDjOAb8xuhf/zJ3yaen8NGswfKWwQluga/52SchFClrR99xEI93s=", map.get("dataSignature"));
-        assertEquals(null, map.get("sharedKeyEnc"));
-        assertEquals(null, map.get("pubKeyCS"));
+    }
+
+    @After
+    public void tearDown() {
     }
 
 }


### PR DESCRIPTION
## What I did

Developed "LlookupAllResponseTransformer" which transforms the `llookup:all` response

## How it works
`AtClient._get(Keys.SelfKey)` is a great illustration of how `LlookupAllResponseTransformer` is implemented.

In step 2, we fetch the `llookup:all` response. This response string looks something like `{"key":"...", "data":"...", "metaData":{"createdBy": "...", ...}}`

In step 3, we transform the String into a `LlookupAllResponse` object which is in `org.atsign.common.response_models`. See this [commit](https://github.com/atsign-foundation/at_java/commit/a3e04ef942b58902c88bdbd1bbdad6a32f9d8508) to see what the model looks like. The model uses the `@JsonProperty` tag which comes from jackson's library. The Transformer essentially fills up the Model's fields. Now fields like `model.data` and `model.metaData` are defined.

```java
private String _get(SelfKey key) throws AtException {
    // 1. build command
    String command = null;
    LlookupVerbBuilder builder = new LlookupVerbBuilder();
    builder.with(key, LlookupVerbBuilder.Type.ALL);
    command = builder.build();
    // 2. execute command
    Secondary.Response rawResponse = secondary.executeCommand(command, false);
    if (rawResponse.isError) {
        throw new AtException("Failed to " + command + " : " + rawResponse.error);
    }
    // 3. transform the data to a LlookupAllResponse object
    LlookupAllResponse model = null;
    LlookupAllResponseTransformer transformer = new LlookupAllResponseTransformer();
    model = transformer.transform(rawResponse); // contains variables for data we want from the `llookup:all:<fullKeyName>` command (e.g. model.
metaData.ttl)
    // 3. decrypt the value
    String decryptedValue = null;
    String encryptedValue = model.data;
    String selfEncryptionKey = keys.get(KeysUtil.selfEncryptionKeyName);
    try {
        decryptedValue = EncryptionUtil.aesDecryptFromBase64(encryptedValue, selfEncryptionKey);
    } catch (NoSuchPaddingException | NoSuchAlgorithmException | InvalidAlgorithmParameterException | InvalidKeyException | IllegalBlockSizeException | 
BadPaddingException | NoSuchProviderException e) {
        throw new AtException("Failed to " + command + " : " + e.getMessage(), e);
    }
    // 4. update metadata. squash the fetchedMetadata with current key.metadata (fetchedMetadata has higher priority)
    Metadata fetchedMetadata = Metadata.fromModel(model.metaData);
    key.metadata = Metadata.squash(fetchedMetadata, key.metadata);
    return decryptedValue;
}
```

## Other Notes

1. Tests for the Transformer can be found [here](https://github.com/atsign-foundation/at_java/commit/8a342e314f282d951f7c16e40e9131c861370a57)
2. `Metadata.fromModel` creates a Keys.Metadata object for you. See [here](https://github.com/atsign-foundation/at_java/commit/e70be4ea68b0854b90a5c3e1c5d7e1c0a61b1170)  
3. Only `_get(SelfKey)` and `_get(PublicKey)` use the Transformer for now...
4. Added comments for the other `_delete` and `_put` methods 

## Closes

closes #33 