### PR TITLE
feat: CameraUtil and image <-> byte[]

### DIFF
--- a/at_client/pom.xml
+++ b/at_client/pom.xml
@@ -96,6 +96,11 @@
 			<version>4.7.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.sarxos</groupId>
+			<artifactId>webcam-capture</artifactId>
+			<version>0.3.12</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/at_client/src/main/java/org/atsign/client/util/CameraUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/CameraUtil.java
@@ -36,9 +36,6 @@ import java.util.stream.Collectors;
 
 public class CameraUtil{
 
-    public static final String START = "START";
-    public static final String STOP = "STOP";
-    public static final String EXIT = "EXIT";
     static Webcam webcam  = null;
 
     /**

--- a/at_client/src/main/java/org/atsign/client/util/CameraUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/CameraUtil.java
@@ -1,0 +1,153 @@
+package org.atsign.client.util;
+
+import com.github.sarxos.webcam.Webcam;
+import org.apache.commons.lang3.StringUtils;
+import org.atsign.common.AtException;
+
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+/**
+ *
+ * 5/10/2022
+ * Author- Kumar Aggarrwal
+ *
+ * CameraUtil
+ *
+ * This Utility class can be used to capture a stream from the camera and get the result in list of byte[] OR capture a single image from camera into byte[]
+ * Camera name can be provided to chose which camera would be used to capture.
+ *
+ * usage:
+ *
+ *      CameraUtil.getCameraStream(); //For DefaultCamera
+ *      CameraUtil.getCameraStream(String cameraName); for a specific camera
+ *      CameraUtil.getCaptureSingleImage(); //For DefaultCamera
+ *      CameraUtil.getCaptureSingleImage(String cameraName); //For a specific camera
+ *
+ *      //example for camera Name: "Webcam HD Webcam: HD Webcam /dev/video0"
+ *      //Check you system drivers to identify camera name or use getAllCams method here
+ *
+ */
+
+public class CameraUtil{
+
+    public static final String START = "START";
+    public static final String STOP = "STOP";
+    public static final String EXIT = "EXIT";
+    static Webcam webcam  = null;
+
+    /**
+     * captures a single image from default camera
+     * @return
+     */
+    public static BufferedImage getSingleImage(){
+        webcam = getWebcam(StringUtils.EMPTY);
+        if(!webcam.isOpen()){
+            webcam.open();
+        }
+        return webcam.getImage();
+    }
+
+    /**
+     * captures a single image from default camera
+     * @param cameraName
+     * @return
+     */
+    public static BufferedImage getSingleImage(String cameraName){
+        webcam = getWebcam(cameraName);
+        if(!webcam.isOpen()){
+            webcam.open();
+        }
+        return webcam.getImage();
+    }
+
+
+    /**
+     * This return all webcams connected to the system
+     * @return
+     */
+    public static List<String> getAllCams(){
+
+        return Webcam.getWebcams().stream().map(webcam1 -> webcam1.getName()).collect(Collectors.toList());
+
+    }
+
+    /**
+     * closes the camera if opened
+     */
+    public static void closeCamera(){
+        if(webcam.isOpen()) webcam.close();
+    }
+
+    /**
+     * return the camera stream into list of byte[] from a specific camera
+     * @param cameraName
+     * @return
+     * @throws AtException
+     * @throws IOException
+     */
+    public static List<byte[]> getCameraStream(String cameraName) throws AtException, IOException {
+
+        webcam = getWebcam(cameraName);
+        validateCamera(webcam);
+        webcam.open();
+        List<byte[]> stream = captureStream(webcam);
+        closeCamera();
+        return stream;
+    }
+
+
+    private static List<byte[]> captureStream(Webcam webcam) throws IOException {
+        List<byte[]> resultList = new ArrayList<>();
+
+        //This message could be configured via properties later
+        System.out.println("Stream capture starting...\n Prese Enter to stop the capture and return the result in byte array");
+        while (System.in.available() == 0) {
+            resultList.add(ImageUtil.toByteArray(getSingleImage()));
+
+        }
+        return resultList;
+    }
+
+    /**
+     * return the camera stream into list of byte[] from a default camera
+     * @return
+     * @throws AtException
+     * @throws IOException
+     */
+    public static List<byte[]> getCameraStream() throws AtException, IOException {
+        webcam = getWebcam(StringUtils.EMPTY);
+        validateCamera(webcam);
+        webcam.open();
+        List<byte[]> stream = captureStream(webcam);
+        closeCamera();
+        return stream;
+    }
+
+    private static void validateCamera(Webcam webcam) throws AtException {
+
+        if(webcam == null){
+            throw new AtException("WebCam is not detected, Please unlock your camera");
+        }
+    }
+
+    private static Webcam getWebcam(String name){
+
+        Webcam webcam = null;
+        if(StringUtils.isEmpty(name)){
+            webcam = Webcam.getDefault();
+        }
+        else{
+            webcam = Webcam.getWebcamByName(name);
+        }
+        return webcam;
+    }
+
+
+
+}

--- a/at_client/src/main/java/org/atsign/client/util/ImageUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/ImageUtil.java
@@ -1,0 +1,104 @@
+package org.atsign.client.util;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.util.Optional;
+
+/**
+ *
+ * 5/10/2022
+ * Author- Kumar Aggarrwal
+ *
+ * ImageUtil
+ *
+ * This utility class can be used to convert buffered image to byte[] and vice versa, it can also be used to save image to memory
+ * Image format and file location can be provided, default format is 'jpg' and default location would be classpath
+ *
+ */
+
+public class ImageUtil {
+
+
+    private static final String DEFAULT_FORMAT = "jpg";
+    private static final String IMAGE = "image";
+
+    /**
+     * Converts BufferedIamge to byte[] with a given format
+     * @param image
+     * @param format
+     * @return
+     * @throws IOException
+     */
+    public static byte[] toByteArray(BufferedImage image, String format)
+            throws IOException {
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(image, format, baos);
+        byte[] bytes = baos.toByteArray();
+        return bytes;
+
+    }
+
+    /**
+     * Converts BufferedIamge to byte[] with a given format
+     * @param image
+     * @return
+     * @throws IOException
+     */
+    public static byte[] toByteArray(BufferedImage image)
+            throws IOException {
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(image, DEFAULT_FORMAT, baos);
+        byte[] bytes = baos.toByteArray();
+        return bytes;
+
+    }
+
+    /**
+     * Convert byte[] to bufferedImage
+     * @param bytes
+     * @return
+     * @throws IOException
+     */
+    public static BufferedImage toBufferedImage(byte[] bytes)
+            throws IOException {
+
+        InputStream is = new ByteArrayInputStream(bytes);
+        BufferedImage image = ImageIO.read(is);
+        return image;
+
+    }
+
+
+    /**
+     * Saves the image to the disk with image format
+     * @param image
+     * @param format
+     * @param file
+     * @throws IOException
+     */
+    public static void saveImage(BufferedImage image, String format, Optional<File> file) throws IOException {
+
+        File fileToCreate = file.isPresent() ? file.get() : new File(IMAGE.concat(".").concat(format));
+        ImageIO.write(image, format, fileToCreate);
+
+    }
+
+    /**
+     * Saves the images to the disk with default format
+     * @param image
+     * @param file
+     * @throws IOException
+     */
+    public static void saveImage(BufferedImage image, Optional<File> file) throws IOException {
+
+        File fileToCreate = file.isPresent() ? file.get() : new File(IMAGE.concat(".").concat(DEFAULT_FORMAT));
+        ImageIO.write(image, DEFAULT_FORMAT, fileToCreate);
+
+    }
+
+
+
+}


### PR DESCRIPTION
**- Description for the changelog**
Two Utility classes are added
1. CameraUtil 
 This Utility class can be used to capture a stream from the camera and get the result in list of byte[] OR capture a single image from camera into byte[]. Camera name can be provided to chose which camera would be used to capture.


2. ImageUtil
This utility class can be used to convert buffered image to byte[] and vice versa, it can also be used to save image to memory
Image format and file location can be provided, default format is 'jpg' and default location would be classpath

How to use: Check the comments in both classes, examples have been provided.
closes #52
closes #54 