### PR TITLE
fix: fix `cached:` prefix in Scan CLI

### DIFF
--- a/at_client/src/main/java/org/atsign/client/cli/Scan.java
+++ b/at_client/src/main/java/org/atsign/client/cli/Scan.java
@@ -101,7 +101,7 @@ public class Scan {
         System.out.println("atKeys: {");
         for(int i = 0; i < atKeys.size(); i++) {
             AtKey atKey = atKeys.get(i);
-            System.out.println("  " + i + ":  " + atKey.toString());
+            System.out.println("  " + i + ":  " + (atKey.metadata.isCached ? "cached:" : "") + atKey.toString());
         }
         System.out.println("}");
     }


### PR DESCRIPTION
## What I did

Checked for `isCached` metadata and prepend `cached:` to the key name if `isCached==true`