### PR TITLE
chore: use jackson rather than snakeyaml for handling yaml

### DIFF
--- a/.github/workflows/at_client.yml
+++ b/.github/workflows/at_client.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - trunk
-    paths:
-      - at_client/**
   pull_request:
     branches:
       - trunk
-    paths:
-      - at_client/**
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/at_client/pom.xml
+++ b/at_client/pom.xml
@@ -70,7 +70,7 @@
 				</executions>
 			</plugin>
 
-			<!-- sources attachments for maven dependnecy -->
+			<!-- sources attachments for maven dependency -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
@@ -149,32 +149,33 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.13.3</version>
+			<version>2.14.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.13.3</version>
+			<version>2.14.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.4.1</version>
+			<version>2.14.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+			<version>2.14.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15to18</artifactId>
-			<version>1.71</version>
+			<version>1.72</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<version>1.30</version>
-		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -189,17 +190,17 @@
 		<dependency>
 			<groupId>info.picocli</groupId>
 			<artifactId>picocli</artifactId>
-			<version>4.6.3</version>
+			<version>4.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-inline</artifactId>
-			<version>4.7.0</version>
+			<version>4.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>
-			<version>4.7.0</version>
+			<version>4.8.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/at_client/src/main/java/org/atsign/client/cli/Register.java
+++ b/at_client/src/main/java/org/atsign/client/cli/Register.java
@@ -8,6 +8,7 @@ import org.atsign.common.RegisterApiTask;
 import org.atsign.common.AtException;
 import org.atsign.config.ConfigReader;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -65,7 +66,7 @@ public class Register implements Callable<String> {
         return "Done.";
     }
 
-    void readParameters() {
+    void readParameters() throws IOException {
 
         // checks to ensure only either of email or super-API key are provided as args.
         // if super-API key is provided uses registrar v3, otherwise uses registrar v2.

--- a/at_client/src/main/java/org/atsign/config/ConfigReader.java
+++ b/at_client/src/main/java/org/atsign/config/ConfigReader.java
@@ -12,9 +12,9 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
  * Loads, reads and returns properties from the configuration file in the resources
  */
 public class ConfigReader {
-    private static Map<String, Object> config;
+    private static HashMap<String, Object> config;
 
-    private static ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
     
     public static String getProperty(String property, String subProperty) throws IOException {
         if (config == null){
@@ -38,6 +38,7 @@ public class ConfigReader {
      */
     public static void loadConfig() throws IOException {
         InputStream inputStream = ClassLoader.getSystemResourceAsStream("config.yaml");
+        //noinspection unchecked
         config = mapper.readValue(inputStream, HashMap.class);
     }
 }

--- a/at_client/src/main/java/org/atsign/config/ConfigReader.java
+++ b/at_client/src/main/java/org/atsign/config/ConfigReader.java
@@ -1,17 +1,22 @@
 package org.atsign.config;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Map;
 
-import org.yaml.snakeyaml.Yaml;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 /**
  * Loads, reads and returns properties from the configuration file in the resources
  */
 public class ConfigReader {
     private static Map<String, Object> config;
+
+    private static ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
     
-    public static String getProperty(String property, String subProperty) {
+    public static String getProperty(String property, String subProperty) throws IOException {
         if (config == null){
             loadConfig();
         }
@@ -20,7 +25,7 @@ public class ConfigReader {
         return propertyMap.get(subProperty);
     }
 
-    public static String getProperty(String property) {
+    public static String getProperty(String property) throws IOException {
         if (config == null){
             loadConfig();
         }
@@ -31,9 +36,8 @@ public class ConfigReader {
      * Loads configuration properties from the yaml provided in the java/src/main/resources
      * Stores these key-value pairs in the config map
      */
-    public static void loadConfig() {
+    public static void loadConfig() throws IOException {
         InputStream inputStream = ClassLoader.getSystemResourceAsStream("config.yaml");
-        Yaml configYaml = new Yaml();
-        config = configYaml.load(inputStream);
+        config = mapper.readValue(inputStream, HashMap.class);
     }
 }

--- a/at_client/src/test/java/org/atsign/common/ConfigReaderTest.java
+++ b/at_client/src/test/java/org/atsign/common/ConfigReaderTest.java
@@ -5,10 +5,12 @@ import static org.junit.Assert.assertEquals;
 import org.atsign.config.ConfigReader;
 import org.junit.Test;
 
+import java.io.IOException;
+
 public class ConfigReaderTest {
     
     @Test
-    public void getRegistrarUrl(){
+    public void getRegistrarUrl() throws IOException {
 
         assertEquals("https://my.atsign.com/api/app/v2", ConfigReader.getProperty("REGISTRAR_URL"));
         assertEquals("https://my.atsign.com/api/app/v2", ConfigReader.getProperty("registrar", "url"));
@@ -17,19 +19,19 @@ public class ConfigReaderTest {
     }
 
     @Test
-    public void getRootDomain(){
+    public void getRootDomain() throws IOException {
         assertEquals("root.atsign.org", ConfigReader.getProperty("ROOT_DOMAIN"));
         assertEquals("root.atsign.org", ConfigReader.getProperty("rootServer", "domain"));
     }
 
     @Test
-    public void getRootPort(){
+    public void getRootPort() throws IOException {
         assertEquals("64", ConfigReader.getProperty("ROOT_PORT"));
         assertEquals("64", ConfigReader.getProperty("rootServer", "port"));
     }
 
     @Test
-    public void getApiKey(){
+    public void getApiKey() throws IOException {
         assertEquals("477b-876u-bcez-c42z-6a3d", ConfigReader.getProperty("API_KEY"));
         assertEquals("477b-876u-bcez-c42z-6a3d", ConfigReader.getProperty("registrar", "apiKey"));
     }


### PR DESCRIPTION
**- What I did**
chore: use jackson rather than snakeyaml for handling yaml
chore: upgrade some dependencies
chore: remove "paths: - at_client/**" from our github actions config for on:push and on:pull-request
style: fix some lints

**- How I did it**
* Removed snakeyaml dependency from pom.xml
* Added dependency on jackson-dataformat-yaml package
* Changed ConfigReader code to use jackson library to read the yaml

**- How to verify it**
Tests pass

**- Description for the changelog**
chore: use jackson rather than snakeyaml for handling yaml
