### PR TITLE
feat: check for shared key created by us

### DIFF
--- a/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
@@ -377,7 +377,12 @@ public class AtClientImpl implements AtClient {
 
     private String _getSharedByOtherWithMe(SharedKey sharedKey) throws AtException {
         String what;
-        String shareEncryptionKey = getEncryptionKeySharedByOther(sharedKey);
+        String shareEncryptionKey = null;
+        try{
+            shareEncryptionKey = getEncryptionKeySharedByOther(sharedKey);
+        } catch (AtException e) {
+            shareEncryptionKey = getEncryptionKeySharedByMe(sharedKey);
+        }
 
         // first, try to fetch cached - e.g. if I'm @bob, I would first "llookup:cached:@bob:some.key.name@alice"
         what = "llookup cached " + sharedKey;
@@ -625,6 +630,9 @@ public class AtClientImpl implements AtClient {
         Secondary.Response rawResponse;
         String command = "";
         String toLookup = "shared_key." + key.sharedWith.withoutPrefix() + atSign;
+        if(key.sharedWith.withoutPrefix().equals(atSign.withoutPrefix())) {
+            toLookup = "shared_key." + key.sharedBy.withoutPrefix() + atSign;
+        }
         try {
             command = "llookup:" + toLookup;
             rawResponse = secondary.executeCommand(command, false);


### PR DESCRIPTION
## What I did


1. The code below fixes the case of where `sharedWith` and the authenticated `atSign` are the same atSign. In that case, we wouldn't want to be looking up a key like `shared_key.alice@alice` so we get the `sharedBy` instead.
```java
String toLookup = "shared_key." + key.sharedWith.withoutPrefix() + atSign;
if(key.sharedWith.withoutPrefix().equals(atSign.withoutPrefix())) {
    toLookup = "shared_key." + key.sharedBy.withoutPrefix() + atSign;
}
```

2. For getting data from another atSign (shared with me), we have to find the shared aes key. First we check if it's shared by them with us and if that does not exist, we will try finding the shared key created by us shared with them.

```java
private String _getSharedByOtherWithMe(SharedKey sharedKey) throws AtException {
    String shareEncryptionKey = null;
    try{
        shareEncryptionKey = getEncryptionKeySharedByOther(sharedKey);
    } catch (AtException e) {
        shareEncryptionKey = getEncryptionKeySharedByMe(sharedKey);
    }
```