### PR TITLE
feat: Generate 2048-bit RSA keypairs rather than 1024-bit

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -47,7 +47,8 @@ jobs:
         install \
         deploy \
         --batch-mode \
-        --no-transfer-progress
+        --no-transfer-progress \
+        -Dgpg.skip=false
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/at_client/pom.xml
+++ b/at_client/pom.xml
@@ -19,6 +19,7 @@
 		<skipTests>false</skipTests>
 		<skipUnitTests>${skipTests}</skipUnitTests>
 		<skipIntegrationTests>${skipTests}</skipIntegrationTests>
+		<gpg.skip>true</gpg.skip>
 	</properties>
 
 	<licenses>

--- a/at_client/src/main/java/org/atsign/client/cli/REPL.java
+++ b/at_client/src/main/java/org/atsign/client/cli/REPL.java
@@ -33,19 +33,23 @@ public class REPL {
     public static void main(String[] args) {
         String rootUrl; // e.g. "root.atsign.org:64";
         AtSign atSign;  // e.g. "@alice";
+        boolean verbose = false;
 
-        if (args.length != 3) {
-            System.err.println("Usage: REPL <rootUrl> <atSign> <seeEncryptedNotifications == 'true|false'>");
+        if (args.length < 3) {
+            System.err.println("Usage: REPL <rootUrl> <atSign> <seeEncryptedNotifications == 'true|false'> [<verbose == 'true|false'>]");
             System.exit(1);
         }
 
         rootUrl = args[0];
         atSign = new AtSign(args[1]);
         boolean seeEncryptedNotifications = Boolean.parseBoolean(args[2]);
+        if (args.length >= 4) {
+            verbose = Boolean.parseBoolean(args[3]);
+        }
 
         AtClient atClient;
         try {
-            atClient = AtClient.withRemoteSecondary(atSign, ArgsUtil.createAddressFinder(rootUrl), false);
+            atClient = AtClient.withRemoteSecondary(atSign, ArgsUtil.createAddressFinder(rootUrl), verbose);
 
             System.out.println("org.atsign.client.core.Client connected OK");
 
@@ -107,7 +111,8 @@ public class REPL {
                             } else if(keyType.equals(KeyStringUtil.KeyType.SHARED_KEY)) {
                                 SharedKey sk = Keys.SharedKey.fromString(fullKeyName);
                                 String value = client.get(sk).get();
-                                System.out.println("  => \033[31m" + value + "\033[0m");                            } else if(keyType.equals(KeyStringUtil.KeyType.PRIVATE_HIDDEN_KEY)) {
+                                System.out.println("  => \033[31m" + value + "\033[0m");
+                            } else if(keyType.equals(KeyStringUtil.KeyType.PRIVATE_HIDDEN_KEY)) {
                                 throw new AtException("PrivateHiddenKey is not implemented yet");
                             } else {
                                 throw new AtException("Could not evaluate the key type of: " + fullKeyName);

--- a/at_client/src/main/java/org/atsign/client/util/EncryptionUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/EncryptionUtil.java
@@ -38,7 +38,7 @@ public class EncryptionUtil {
 
     public static KeyPair generateRSAKeyPair() throws NoSuchAlgorithmException {
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-        generator.initialize(1024);
+        generator.initialize(2048);
         return generator.generateKeyPair();
     }
 


### PR DESCRIPTION
**- What I did**
feat: Generate 2048-bit RSA keypairs rather than 1024-bit
feat: add verbose option to REPL
build: Modified pom.xml to default the `gpg.skip` property to true so people don't need to remember to say -Dgpg.skip=true on the command line when doing `mvn clean install` or whatever
build: Modified the maven-deploy workflow to explicitly set the gpg.skip property to false

**- Description for the changelog**
feat: Generate 2048-bit RSA keypairs rather than 1024-bit
feat: add verbose option to REPL
build: Modified pom.xml to default the `gpg.skip` property to true so people don't need to remember to say -Dgpg.skip=true on the command line when doing `mvn clean install` or whatever
build: Modified the maven-deploy workflow to explicitly set the gpg.skip property to false
