### PR TITLE
feat: Various REPL enhancements

### DIFF
--- a/at_client/pom.xml
+++ b/at_client/pom.xml
@@ -261,6 +261,11 @@
 			<artifactId>webcam-capture</artifactId>
 			<version>0.3.12</version>
 		</dependency>
+		<dependency>
+			<groupId>org.fusesource.jansi</groupId>
+			<artifactId>jansi</artifactId>
+			<version>2.4.0</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/at_client/src/main/java/org/atsign/client/api/AtClient.java
+++ b/at_client/src/main/java/org/atsign/client/api/AtClient.java
@@ -172,4 +172,5 @@ public interface AtClient extends Secondary, AtEvents.AtEventBus {
     CompletableFuture<String> put(PublicKey publicKey, byte[] value);
 
     CompletableFuture<List<AtKey>> getAtKeys(String regex);
+    CompletableFuture<List<AtKey>> getAtKeys(String regex, boolean fetchMetadata);
 }

--- a/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
@@ -105,12 +105,14 @@ public class AtClientImpl implements AtClient {
                 if (eventData.get("value") != null) {
                     String key = (String) eventData.get("key");
                     String encryptedValue = (String) eventData.get("value");
+                    @SuppressWarnings("unchecked") Map<String, Object> metadata = (Map<String, Object>) eventData.get("metadata");
+                    String ivNonce = (String) metadata.get("ivNonce");
 
                     try {
                         // decrypt it with the symmetric key that the other atSign shared with me
                         String encryptionKeySharedByOther = getEncryptionKeySharedByOther(SharedKey.fromString(key));
 
-                        String decryptedValue = EncryptionUtil.aesDecryptFromBase64(encryptedValue, encryptionKeySharedByOther);
+                        String decryptedValue = EncryptionUtil.aesDecryptFromBase64(encryptedValue, encryptionKeySharedByOther, ivNonce);
                         HashMap<String, Object> newEventData = new HashMap<>(eventData);
                         newEventData.put("decryptedValue", decryptedValue);
                         eventBus.publishEvent(decryptedUpdateNotification, newEventData);
@@ -314,9 +316,14 @@ public class AtClientImpl implements AtClient {
 
     @Override
     public CompletableFuture<List<AtKey>> getAtKeys(String regex) {
+        return getAtKeys(regex, true);
+    }
+
+    @Override
+    public CompletableFuture<List<AtKey>> getAtKeys(String regex, boolean fetchMetadata) {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                return _getAtKeys(regex);
+                return _getAtKeys(regex, fetchMetadata);
             } catch (Exception e) {
                 throw new CompletionException(e);
             }
@@ -437,20 +444,7 @@ public class AtClientImpl implements AtClient {
         command = builder.build();
 
         // 2. execute command
-        Response response;
-        try {
-            response = secondary.executeCommand(command, true);
-        } catch (IOException e) {
-            throw new AtSecondaryConnectException("Failed to execute " + command, e);
-        }
-
-        // 3. transform the data to a LlookupAllResponse object
-        LookupResponse fetched;
-        try {
-            fetched = json.readValue(response.getRawDataResponse(), LookupResponse.class);
-        } catch (JsonProcessingException e) {
-            throw new AtResponseHandlingException("Failed to parse JSON " + response.getRawDataResponse(), e);
-        }
+        LookupResponse fetched = getLookupResponse(command);
 
         // 3. decrypt the value
         String decryptedValue;
@@ -526,20 +520,7 @@ public class AtClientImpl implements AtClient {
         }
 
         // 2. run the command
-        Response response;
-        try {
-            response = secondary.executeCommand(command, true);
-        } catch (IOException e) {
-            throw new AtSecondaryConnectException("Failed to execute " + command, e);
-        }
-
-        // 3. transform the data to a LlookupAllResponse object
-        LookupResponse fetched;
-        try {
-            fetched = json.readValue(response.getRawDataResponse(), LookupResponse.class);
-        } catch (JsonProcessingException e) {
-            throw new AtResponseHandlingException("Failed to parse JSON " + response.getRawDataResponse(), e);
-        }
+        LookupResponse fetched = getLookupResponse(command);
 
         // 4. update key object metadata
         key.metadata = Metadata.squash(fetched.metaData, key.metadata);
@@ -591,7 +572,7 @@ public class AtClientImpl implements AtClient {
     private String _put(SelfKey selfKey, byte[] value) throws AtException {throw new RuntimeException("Not Implemented");}
     private String _put(PublicKey publicKey, byte[] value) throws AtException {throw new RuntimeException("Not Implemented");}
 
-    private List<AtKey> _getAtKeys(String regex) throws AtException {
+    private List<AtKey> _getAtKeys(String regex, boolean fetchMetadata) throws AtException {
         ScanVerbBuilder scanVerbBuilder = new ScanVerbBuilder();
         scanVerbBuilder.setRegex(regex);
         scanVerbBuilder.setShowHidden(true); 
@@ -607,17 +588,19 @@ public class AtClientImpl implements AtClient {
         List<AtKey> atKeys = new ArrayList<>();
         for(String atKeyRaw : rawArray) { // eg atKeyRaw == @bob:phone@alice
             AtKey atKey = Keys.fromString(atKeyRaw);
-            String llookupCommand = "llookup:meta:" + atKeyRaw;
-            Response llookupMetaResponse;
-            try {
-                llookupMetaResponse = secondary.executeCommand(llookupCommand, true);
-            } catch (IOException e) {
-                throw new AtSecondaryConnectException("Failed to execute " + llookupCommand, e);
-            }
-            try {
-                atKey.metadata = Metadata.squash(atKey.metadata, Metadata.fromJson(llookupMetaResponse.getRawDataResponse())); // atKey.metadata has priority over llookupMetaRaw.data
-            } catch (JsonProcessingException e) {
-                throw new AtResponseHandlingException("Failed to parse JSON " + llookupMetaResponse.getRawDataResponse(), e);
+            if (fetchMetadata) {
+                String llookupCommand = "llookup:meta:" + atKeyRaw;
+                Response llookupMetaResponse;
+                try {
+                    llookupMetaResponse = secondary.executeCommand(llookupCommand, true);
+                } catch (IOException e) {
+                    throw new AtSecondaryConnectException("Failed to execute " + llookupCommand, e);
+                }
+                try {
+                    atKey.metadata = Metadata.squash(atKey.metadata, Metadata.fromJson(llookupMetaResponse.getRawDataResponse())); // atKey.metadata has priority over llookupMetaRaw.data
+                } catch (JsonProcessingException e) {
+                    throw new AtResponseHandlingException("Failed to parse JSON " + llookupMetaResponse.getRawDataResponse(), e);
+                }
             }
             atKeys.add(atKey);
         }
@@ -631,6 +614,25 @@ public class AtClientImpl implements AtClient {
     //
     // Internal utility methods. Will move these to another class later, so that other AtClient implementations can easily use them.
     //
+
+    private LookupResponse getLookupResponse(String command) throws AtException {
+        Response response;
+        try {
+            response = secondary.executeCommand(command, true);
+        } catch (IOException e) {
+            throw new AtSecondaryConnectException("Failed to execute " + command, e);
+        }
+
+        // 3. transform the data to a LlookupAllResponse object
+        LookupResponse fetched;
+        try {
+            fetched = json.readValue(response.getRawDataResponse(), LookupResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new AtResponseHandlingException("Failed to parse JSON " + response.getRawDataResponse(), e);
+        }
+        return fetched;
+    }
+
     private String getEncryptionKeySharedByMe(SharedKey key) throws AtException {
         // llookup:shared_key.bob@alice
         Secondary.Response rawResponse;

--- a/at_client/src/main/java/org/atsign/client/api/impl/connections/AtMonitorConnection.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/connections/AtMonitorConnection.java
@@ -23,9 +23,6 @@ public class AtMonitorConnection extends AtSecondaryConnection implements Runnab
 
     private boolean _shouldBeRunning = false;
     private void setShouldBeRunning(boolean b) {
-        if (_shouldBeRunning != b) {
-            System.err.println("Monitor setting shouldBeRunning to [" + b + "]");
-        }
         _shouldBeRunning = b;
     }
 
@@ -127,9 +124,6 @@ public class AtMonitorConnection extends AtSecondaryConnection implements Runnab
     @SuppressWarnings("unchecked")
     @Override
     public void run() {
-        System.err.println("***");
-        System.err.println("*** Monitor thread starting");
-        System.err.println("***");
         String what = "";
         // 			call executeCommand("monitor:<time>")
         //			while scanner.nextLine()

--- a/at_client/src/main/java/org/atsign/client/cli/DumpKeys.java
+++ b/at_client/src/main/java/org/atsign/client/cli/DumpKeys.java
@@ -1,0 +1,15 @@
+package org.atsign.client.cli;
+
+import org.atsign.client.util.KeysUtil;
+import org.atsign.common.AtSign;
+
+import java.util.Map;
+
+public class DumpKeys {
+    public static void main(String[] args) throws Exception {
+        Map<String, String> keys = KeysUtil.loadKeys(new AtSign(args[0]));
+        for (String key : keys.keySet()) {
+            System.out.println("\tkey: " + key + "\n\t\tvalue: " + keys.get(key) + "\n");
+        }
+    }
+}

--- a/at_client/src/main/java/org/atsign/client/cli/REPL.java
+++ b/at_client/src/main/java/org/atsign/client/cli/REPL.java
@@ -15,13 +15,15 @@ import org.atsign.common.Keys.SharedKey;
 import org.atsign.common.exceptions.AtIllegalArgumentException;
 import org.atsign.common.exceptions.AtInvalidSyntaxException;
 import org.atsign.common.exceptions.AtNotYetImplementedException;
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.AnsiConsole;
 
 import java.io.IOException;
-import java.time.OffsetDateTime;
 import java.util.*;
 
 import static org.atsign.client.api.AtEvents.AtEventType.decryptedUpdateNotification;
 import static org.atsign.client.api.AtEvents.AtEventType.updateNotification;
+import static org.fusesource.jansi.Ansi.ansi;
 
 /**
  * A command-line interface half-example half-utility which connects
@@ -30,6 +32,8 @@ import static org.atsign.client.api.AtEvents.AtEventType.updateNotification;
  */
 public class REPL {
     public static void main(String[] args) {
+        AnsiConsole.systemInstall();
+
         String rootUrl; // e.g. "root.atsign.org:64";
         AtSign atSign;  // e.g. "@alice";
         boolean verbose = false;
@@ -48,15 +52,16 @@ public class REPL {
 
         AtClient atClient;
         try {
+            System.out.print(ansi().cursorToColumn(0).bold().fg(Ansi.Color.BLUE).a("Connecting ... ").reset());
             atClient = AtClient.withRemoteSecondary(atSign, ArgsUtil.createAddressFinder(rootUrl), verbose);
 
-            System.out.println("org.atsign.client.core.Client connected OK");
+            System.out.println(ansi().fg(Ansi.Color.GREEN).a("connected. ").reset().a("Type '/help' to see help").reset());
 
             REPL repl = new REPL(atClient, seeEncryptedNotifications);
             repl.repl();
         } catch (IOException | AtException e) {
+            System.out.println(ansi().fg(Ansi.Color.RED).a("connection failed: " + e).reset());
             e.printStackTrace();
-            System.err.println("Calling System.exit");
             System.exit(1);
         }
     }
@@ -78,9 +83,9 @@ public class REPL {
     }
 
     public void repl() throws AtException {
-        System.out.println("Type '/help' to see help");
         Scanner cliScanner = new Scanner(System.in);
-        System.out.print(client.getAtSign() + "@ ");
+
+        writePrompt();
 
         while (cliScanner.hasNextLine()) {
             String command = cliScanner.nextLine() + "\n";
@@ -143,7 +148,7 @@ public class REPL {
                         } else if ("scan".equals(verb)) {
                             String regex = "";
                             if(parts.length > 1) regex = parts[1];
-                            List<Keys.AtKey> value = client.getAtKeys(regex).get();
+                            List<Keys.AtKey> value = client.getAtKeys(regex, false).get();
                             System.out.println("  => \033[31m" + value + "\033[0m");
                         } else if("delete".equals(verb)) {
                             String fullKeyName = parts[1];
@@ -166,18 +171,6 @@ public class REPL {
                             } else {
                                 throw new AtIllegalArgumentException("Could not evaluate the key type of: " + fullKeyName);
                             }
-                        } else if("share".equals(verb)) {
-                            // _share <atSign> <keyName> <...data>
-                            // example: I am @bob, run _share @alice test hello world!! | will create a key "@alice:test@bob" with encrypted value "hello world!!"
-
-                            String atSign = parts[1];
-                            String keyName = parts[2];
-                            String value = command.substring(verb.length() + atSign.length() + keyName.length() + 3).trim();
-
-                            String fullKeyName = atSign + ":" + keyName + client.getAtSign();
-                            SharedKey sk = Keys.SharedKey.fromString(fullKeyName);
-                            String data = client.put(sk, value).get();
-                            System.out.println("  => \033[31m" + data + "\033[0m");
                         } else {
                             System.err.println("ERROR: command not recognized: [" + verb + "]");
                         }
@@ -194,14 +187,21 @@ public class REPL {
                     }
                 }
             }
-            System.out.print(client.getAtSign() + "@ ");
+            writePrompt();
         }
         cliScanner.close();
+    }
+
+    void writePrompt() {
+        System.out.print(ansi().bold().fg(Ansi.Color.MAGENTA).a(client.getAtSign() + "@ ").reset());
     }
 
     public static class REPLEventListener implements AtEvents.AtEventListener {
         private final AtClient client;
 
+        void writePrompt() {
+            System.out.print(ansi().bold().fg(Ansi.Color.MAGENTA).a(client.getAtSign() + "@ ").reset());
+        }
         public REPLEventListener(AtClient client) {
             this.client = client;
         }
@@ -217,15 +217,13 @@ public class REPL {
                     sharedKey = Keys.SharedKey.fromString((String) eventData.get("key"));
                     value = (String) eventData.get("value");
                     decryptedValue = (String) eventData.get("decryptedValue");
-                    System.out.println("\t" + OffsetDateTime.now()
-                            + " REPL NOTIFIED with value [" + decryptedValue + "]"
-                            + " for key [" + sharedKey + "]"
-                            + " (encryptedValue was [" + value + "])");
+                    System.out.println("  => Notification ==> \033[31m Key: [" + sharedKey + "]  ==> EncryptedValue [" + value + "]  ==> DecryptedValue [" + decryptedValue + "]" + "\033[0m");
+                    writePrompt();
                 }
                 break;
                 case updateNotificationText: {
                     System.out.println(eventData);
-                    System.out.print(client.getAtSign() + "@ ");
+                    writePrompt();
                 }
                 break;
                 case updateNotification: {
@@ -234,7 +232,7 @@ public class REPL {
                         String encryptedValue = (String) eventData.get("value");
                         decryptedValue = client.get(sharedKey).get();
                         System.out.println("  => Notification ==> \033[31m Key: [" + sharedKey + "]  ==> EncryptedValue [" + encryptedValue + "]  ==> DecryptedValue [" + decryptedValue + "]" + "\033[0m");
-                        System.out.print(client.getAtSign() + "@ ");
+                        writePrompt();
                     } catch (Exception e) {
                         System.err.println("Failed to retrieve " + sharedKey + " : " + e);
                     }
@@ -247,15 +245,26 @@ public class REPL {
     }
 
     public void printHelpInstructions() {
-        System.out.println("\nAtClient REPL | <> = required, [] = optional");
-        System.out.println("  By default, REPL treats input as atProtocol commands. Use / to use AtClient commands (see below)");
-        System.out.println("  AtClient Commands:");
-        System.out.println("    help or /help - print this help message");
-        System.out.println("    /put <key> <value> - put a value to the key (e.g. _put test@bob hello world)");
-        System.out.println("    /get <key> - get a value from the key (e.g. _get test@bob)");
-        System.out.println("    /delete <key> - delete a key (e.g. _delete test@bob)");
-        System.out.println("    /scan [regex] - scan for keys matching the regex (e.g. _scan test@bob.*)");
-        System.out.println("    /share <atSign> <keyName> <...data> - share a key with another atSign (e.g. _share @alice test hello world!!)");
+        System.out.println();
+        System.out.println("AtClient REPL");
+        System.out.println(ansi().render("  Notes:"));
+        System.out.println(ansi().render("    1) By default, REPL treats input as atProtocol commands. Use / for additional commands listed below"));
+        System.out.println(ansi().render("    2) In the usage examples below, it is assumed that the atSign being used is @|bold,green @alice|@"));
+        System.out.println();
+        System.out.println(ansi().render("  @|bold,magenta help|@ or @|bold,magenta /help|@ - print this help message"));
+        System.out.println();
+        System.out.println(ansi().render("  @|bold,magenta /scan|@ @|bold,green [regex]|@ - scan for all records, or all records whose keyNames match the regex (e.g. _scan test@alice.*)"));
+        System.out.println();
+        System.out.println(ansi().render("  @|bold,magenta /put|@ @|bold,green <atKeyName>|@ @|bold,blue <value>|@ - create or update a record with the given atKeyName and with the supplied value - for example:"));
+        System.out.println(ansi().render("    @|bold,magenta /put|@ @|bold,green test@alice|@ @|bold,blue secret secrets|@ will create or update a 'self' record (a record private just to @alice)"));
+        System.out.println(ansi().render("    @|bold,magenta /put|@ @|bold,green @bob:test@alice|@ @|bold,blue Hello, Bob!|@ will create or update a record encrypted for, and then shared with, @bob"));
+        System.out.println();
+        System.out.println(ansi().render("  @|bold,magenta /get|@ @|bold,green <atKeyName>|@ - retrieve a value from the record with this atKeyName - for example:"));
+        System.out.println(ansi().render("    @|bold,magenta /get|@ @|bold,green <atKeyName>|@ - retrieve a value from the record with this atKeyName (e.g. _get test@alice)"));
+        System.out.println();
+        System.out.println(ansi().render("  @|bold,magenta /delete|@ @|bold,green <atKeyName>|@ - delete the record with this atKeyName (e.g. _delete test@alice)"));
+        System.out.println();
+        System.out.println(ansi().render("  @|bold,red NOTE:|@ @|bold,magenta put, get|@ and @|bold,magenta delete|@ will append the current atSign to the atKeyName if not supplied"));
         System.out.println();
     }
 }

--- a/at_client/src/main/java/org/atsign/client/cli/REPL.java
+++ b/at_client/src/main/java/org/atsign/client/cli/REPL.java
@@ -89,7 +89,9 @@ public class REPL {
                 Secondary.Response response;
                 if (command.equals("help") || command.startsWith("_") || command.startsWith("/") || command.startsWith("\\")) {
                     // simple repl for get / put /
-                    command = command.substring(1);
+                    if (! command.equals("help")) {
+                        command = command.substring(1);
+                    }
                     String[] parts = command.split(" ");
                     String verb = parts[0];
                     try {

--- a/at_client/src/main/java/org/atsign/common/Keys.java
+++ b/at_client/src/main/java/org/atsign/common/Keys.java
@@ -109,12 +109,12 @@ public abstract class Keys {
             }
             String[] splitByColon = key.split(":");
             if (splitByColon.length != 2) {
-                throw new IllegalArgumentException("SharedKey.fromString(key) : key must have structure @bob:shared_key@alice");
+                throw new IllegalArgumentException("SharedKey.fromString('" + key + "') : key must have structure @bob:foo.bar@alice");
             }
             String sharedWith = splitByColon[0];
             String[] splitByAtSign = splitByColon[1].split("@");
             if (splitByAtSign.length != 2) {
-                throw new IllegalArgumentException("SharedKey.fromString(key) : key must have structure @bob:shared_key@alice");
+                throw new IllegalArgumentException("SharedKey.fromString('" + key + "') : key must have structure @bob:foo.bar@alice");
             }
             String keyName = splitByAtSign[0];
             String sharedBy = splitByAtSign[1];

--- a/at_client/src/main/scripts/atrepl
+++ b/at_client/src/main/scripts/atrepl
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+function usage {
+  echo "Usage: $scriptName -a <atSign> [-d <atDirectory>] [-v(erbose)]"
+  echo "       When '-d' is not provided, we default to root.atsign.org:64"
+  exit 1
+}
+
+scriptName=$(basename -- "$0")
+cd "$(dirname -- "$0")"
+scriptDir=$(pwd)
+
+unset atSign
+atDirectory=root.atsign.org:64
+verbose="false"
+
+while getopts a:d:v opt; do
+  case $opt in
+    a) atSign=$OPTARG ;;
+    d) atDirectory=$OPTARG ;;
+    v) verbose="true" ;;
+    *) usage ;;
+  esac
+done
+
+shift "$(( OPTIND - 1 ))"
+
+if [ -z "$atSign" ] || [ -z "$atDirectory" ] ; then
+  usage
+fi
+
+# Script dir is <repo_root>/at_client/src/main/scripts
+# We want to run in <repo_root>/at_client
+cd "$scriptDir"/../../..
+
+java -cp "target/at_client-1.0-SNAPSHOT.jar:target/lib/*" org.atsign.client.cli.REPL "$atDirectory" "$atSign" false $verbose
+


### PR DESCRIPTION
**- What I did**
* feat: Various REPL enhancements

**- How I did it**
* feat: Various REPL enhancements
  * Coloured output to help see more clearly what's happening, improved output during startup
  * Improved help instructions
  * Removed /share command, which I found to be confusing as a returning user
  * Added bash script `at_client/src/main/scripts/atrepl` for convenience
* feat: `EncryptionUtil.aesDecryptFromBase64` now uses IV if supplied
* feat: AtClientImpl now knows to use an IV when decrypting notifications
* feat: Added a variation of `AtClient.getAtKeys` which allows you to request that getAtKeys **not** fetch metadata for each key (this can be very time-consuming for large scan results)
* refactor: extracted some duplicated code in AtClientImpl into a new `getLookupResponse` method
* fix: removed some unnecessary output to stdout / stderr

**- How to verify it**
* Tests pass
* Run the `<repo_root>/at_client/src/main/scripts/atrepl` script

**- Description for the changelog**
* feat: Various REPL enhancements

**- Additional context**
First toe in the water of using new encryption metadata ivNonce - this PR will decrypt notifications which were encrypted with an ivNonce, but the get and put methods in the AtClient do not yet understand or use an ivNonce