### PR TITLE
feat: make register client consume registrar v3 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ and have used the Dart/Flutter packages
     * **Get** - gets data which was shared by another @-sign
     * **Delete** - deletes data that this Atsign previously shared with another
   * To run them, having done a mvn install 
-    `java -cp "target/at_client-1.0-SNAPSHOT.jar:target/lib/*" org.atsign.client.cli.REPL` (or Onboard/Share/Get/Delete )
+    `java -cp "target/at_client-1.0-SNAPSHOT.jar:target/lib/*" org.atsign.client.cli.REPL` (or Onboard/Share/Get/Delete/Register )

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ and have used the Dart/Flutter packages
     * **Get** - gets data which was shared by another @-sign
     * **Delete** - deletes data that this Atsign previously shared with another
   * To run them, having done a mvn install 
-    `java -cp "target/client-1.0-SNAPSHOT.jar:target/lib/*" org.atsign.client.cli.REPL` (or Onboard/Share/Get/Delete )
+    `java -cp "target/at_client-1.0-SNAPSHOT.jar:target/lib/*" org.atsign.client.cli.REPL` (or Onboard/Share/Get/Delete )

--- a/at_client/src/main/java/org/atsign/client/cli/Register.java
+++ b/at_client/src/main/java/org/atsign/client/cli/Register.java
@@ -218,7 +218,7 @@ class ValidateOtp extends RegisterApiTask<RegisterApiResult<Map<String, String>>
                     params.get("otp"), params.get("registrarUrl"), params.get("apiKey"),
                     Boolean.parseBoolean(params.get("confirmation")));
             if (apiResponse.equals("retry")) {
-                System.out.println("Incorrect OTP!!! Please re-enter your OTP");
+                System.err.println("Incorrect OTP!!! Please re-enter your OTP");
                 params.put("otp", scanner.nextLine());
                 result.apiCallStatus = ApiCallStatus.retry;
                 result.atException = new AtRegistrarException("Only 3 retries allowed to re-enter OTP - Incorrect OTP entered");

--- a/at_client/src/main/java/org/atsign/client/util/RegisterUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/RegisterUtil.java
@@ -64,8 +64,8 @@ public class RegisterUtil {
      * @throws IOException - thrown if anything goes wrong while using the
      *                     HttpsURLConnection.
      */
-    public Map<String, String> getAtsignV3(String registrarUrl, String apiKey) throws IOException, AtException {
-        return getAtsignV3(registrarUrl, apiKey, "", "");
+    public Map<String, String> getAtsignWithSuperApiKey(String registrarUrl, String apiKey) throws IOException, AtException {
+        return getAtsignWithSuperApiKey(registrarUrl, apiKey, "", "");
     }
 
     /**
@@ -85,8 +85,8 @@ public class RegisterUtil {
      * @throws IOException - thrown if anything goes wrong while using the
      *                     HttpsURLConnection.
      */
-    public Map<String, String> getAtsignV3(String registrarUrl, String apiKey, String atsign,
-            String activationKey)
+    public Map<String, String> getAtsignWithSuperApiKey(String registrarUrl, String apiKey, String atsign,
+                                                        String activationKey)
             throws AtException, IOException {
         Map<String, String> paramsMap = new HashMap<>();
         if (!atsign.isEmpty()) {
@@ -141,7 +141,7 @@ public class RegisterUtil {
             String response = bufferedReader.readLine();
             @SuppressWarnings("unchecked") Map<String, String> responseData = objectMapper.readValue(response, Map.class);
             String data = responseData.get("message");
-            System.out.println("Got response: " + data);
+            System.out.println("\tVerification code: " + data);
             return response.contains("Sent Successfully");
         } else {
             throw new AtRegistrarException(httpsConnection.getResponseCode() + " " + httpsConnection.getResponseMessage());
@@ -251,7 +251,7 @@ public class RegisterUtil {
      * @throws IOException - thrown if anything goes wrong while using the
      *                     HttpsURLConnection.
      */
-    public String activateAtsign(String registrarUrl, String apiKey, AtSign atsign, String activationKey)
+    public String activateAtsignWithSuperApiKey(String registrarUrl, String apiKey, AtSign atsign, String activationKey)
             throws AtException, IOException {
         Map<String, String> paramsMap = Stream.of(
                 new SimpleEntry<>("atSign", atsign.withoutPrefix()),

--- a/at_client/src/main/resources/config.yaml
+++ b/at_client/src/main/resources/config.yaml
@@ -7,10 +7,11 @@ registrar:
   apiKey: "477b-876u-bcez-c42z-6a3d"
 
 registrarV3:
-  url: "https://my.atsign.wtf/api/app/v3"
+  url: "https://my.atsign.com/api/app/v3"
+  apiKey: "477b-876u-bcez-c42z-6a3d"
     
 ##the configurations below are provided for backwards-compatability and will be deprecated in further updates. Kindly use the config structure above for smooth functioning
 API_KEY: "477b-876u-bcez-c42z-6a3d"
 ROOT_DOMAIN: "root.atsign.org"
 ROOT_PORT: "64"
-REGISTRAR_URL: "https://my.atsign.com/api/app/v2"
+REGISTRAR_URL: "https://my.atsign.com/api/app/v3"

--- a/at_client/src/test/java/org/atsign/common/ConfigReaderTest.java
+++ b/at_client/src/test/java/org/atsign/common/ConfigReaderTest.java
@@ -8,14 +8,14 @@ import org.junit.Test;
 import java.io.IOException;
 
 public class ConfigReaderTest {
-    
+
     @Test
     public void getRegistrarUrl() throws IOException {
 
-        assertEquals("https://my.atsign.com/api/app/v2", ConfigReader.getProperty("REGISTRAR_URL"));
+        assertEquals("https://my.atsign.com/api/app/v3", ConfigReader.getProperty("REGISTRAR_URL"));
         assertEquals("https://my.atsign.com/api/app/v2", ConfigReader.getProperty("registrar", "url"));
         //test regsitrar_v3 url
-        assertEquals("https://my.atsign.wtf/api/app/v3", ConfigReader.getProperty("registrarV3", "url"));
+        assertEquals("https://my.atsign.com/api/app/v3", ConfigReader.getProperty("registrarV3", "url"));
     }
 
     @Test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_java/issues/115
**- What I did**
- update incorrect outdated command to use at_java in readme
- changed the config.yaml values point to registrar v3 api
- rename all method/variable names that contained 'v3' -> 'superApi' for more clarity
- fixed log statement being printed twice which asks for user verification code
- minor reformatting of logs and user messages
- updated config_reader tests to match new config

**- How to verify it**
- register should be working without any issues

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: make register client consume registrar v3 api