### PR TITLE
docs: Add OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![gitHub license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_java/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_java)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8116/badge)](https://www.bestpractices.dev/projects/8116)
 
 # The atPlatform for Java developers
 


### PR DESCRIPTION
Improving our OpenSSF Scorecard requires the badge to be found.

**- What I did**

Added OpenSSF Best practice badge to README

**- How I did it**

Pasted in link provided at https://www.bestpractices.dev/en/projects/8116

**- How to verify it**

Badge is visible in rich diff preview

**- Description for the changelog**

docs: Add OpenSSF Best practice badge to README