### PR TITLE
fix: ensure atkey namespace is marshalled by VerbBuilder with() methods

### DIFF
--- a/at_client/src/main/java/org/atsign/common/VerbBuilders.java
+++ b/at_client/src/main/java/org/atsign/common/VerbBuilders.java
@@ -190,7 +190,7 @@ public class VerbBuilders {
 		}
 
 		public void with(AtKey atKey, Object value) {
-			setKeyName(atKey.name);
+			setKeyName(atKey.getFullyQualifiedKeyName());
 			setSharedBy(atKey.sharedBy.toString());
 			if(atKey.sharedWith != null && !atKey.sharedWith.toString().isEmpty()) setSharedWith(atKey.sharedWith.toString());
 			setIsCached(atKey.metadata.isCached);
@@ -293,7 +293,7 @@ public class VerbBuilders {
 		}
 
 		public void with(AtKey atKey, LlookupVerbBuilder.Type type) {
-			setKeyName(atKey.name);
+			setKeyName(atKey.getFullyQualifiedKeyName());
 			setSharedBy(atKey.sharedBy.toString());
 			if(atKey.sharedWith != null && !atKey.sharedWith.toString().isEmpty()) setSharedWith(atKey.sharedWith.toString());
 			setIsHidden(atKey.metadata.isHidden);
@@ -368,7 +368,7 @@ public class VerbBuilders {
 		}
 
 		public void with(SharedKey sharedKey, LookupVerbBuilder.Type type) {
-			setKeyName(sharedKey.name);
+			setKeyName(sharedKey.getFullyQualifiedKeyName());
 			setSharedWith(sharedKey.sharedWith.toString());
 			setType(type);
 		}
@@ -432,7 +432,7 @@ public class VerbBuilders {
 		}
 
 		public void with(PublicKey atKey, PlookupVerbBuilder.Type type) {
-			setKeyName(atKey.name);
+			setKeyName(atKey.getFullyQualifiedKeyName());
 			setSharedBy(atKey.sharedBy.toString());
 			setType(type);
 		}
@@ -498,7 +498,7 @@ public class VerbBuilders {
 		}
 
 		public void with(AtKey atKey) {
-			setKeyName(atKey.name);
+			setKeyName(atKey.getFullyQualifiedKeyName());
 			setSharedBy(atKey.sharedBy.toString());
 			if(atKey.sharedWith != null && !atKey.sharedWith.toString().isEmpty()) setSharedWith(atKey.sharedWith.toString());
 			setIsHidden(atKey.metadata.isHidden);

--- a/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/common/VerbBuildersTest.java
@@ -1,5 +1,7 @@
 package org.atsign.common;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -20,6 +22,7 @@ import org.atsign.common.VerbBuilders.PlookupVerbBuilder;
 import org.atsign.common.VerbBuilders.ScanVerbBuilder;
 import org.atsign.common.VerbBuilders.UpdateVerbBuilder;
 import org.atsign.common.VerbBuilders.PlookupVerbBuilder.Type;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -161,7 +164,43 @@ public class VerbBuildersTest {
 		// TODO with private hidden key when implemented
 	}
 
-	@Test
+    @Test
+    public void testUpdateVerbBuilderForPublicKeyWithNamespace() {
+        PublicKey key = new KeyBuilders.PublicKeyBuilder(new AtSign("@alice"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        UpdateVerbBuilder builder = new UpdateVerbBuilder();
+        builder.with(key, "testvalue");
+
+        assertThat(builder.build(), equalTo("update:isBinary:false:isEncrypted:false:public:test.testns@alice testvalue"));
+    }
+
+    @Test
+    public void testUpdateVerbBuilderForSelfKeyWithNamespace() {
+        SelfKey key = new KeyBuilders.SelfKeyBuilder(new AtSign("@alice"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        UpdateVerbBuilder builder = new UpdateVerbBuilder();
+        builder.with(key, "testvalue");
+
+        assertThat(builder.build(), equalTo("update:isBinary:false:isEncrypted:true:test.testns@alice testvalue"));
+    }
+
+    @Test
+    public void testUpdateVerbBuilderForSharedKeyWithNamespace() {
+        SharedKey key = new KeyBuilders.SharedKeyBuilder(new AtSign("@alice"), new AtSign("@bob"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        UpdateVerbBuilder builder = new UpdateVerbBuilder();
+        builder.with(key, "testvalue");
+
+        assertThat(builder.build(), equalTo("update:isBinary:false:isEncrypted:true:@bob:test.testns@alice testvalue"));
+    }
+
+    @Test
 	public void llookupVerbBuilderTest() {
 		LlookupVerbBuilder builder;
 		String command;
@@ -273,7 +312,43 @@ public class VerbBuildersTest {
 
 	}
 
-	@Test
+    @Test
+    public void testLlookupVerbBuilderFoPublicKeyWithNamespace() {
+        PublicKey key = new KeyBuilders.PublicKeyBuilder(new AtSign("@alice"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        LlookupVerbBuilder builder = new LlookupVerbBuilder();
+        builder.with(key, LlookupVerbBuilder.Type.METADATA);
+
+        assertThat(builder.build(), equalTo("llookup:meta:public:test.testns@alice"));
+    }
+
+    @Test
+    public void testLlookupVerbBuilderForSelfKeyWithNamespace() {
+        SelfKey key = new KeyBuilders.SelfKeyBuilder(new AtSign("@alice"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        LlookupVerbBuilder builder = new LlookupVerbBuilder();
+        builder.with(key, LlookupVerbBuilder.Type.METADATA);
+
+        assertThat(builder.build(), equalTo("llookup:meta:test.testns@alice"));
+    }
+
+    @Test
+    public void testLlookupVerbBuilderForSharedKeyWithNamespace() {
+        SharedKey key = new KeyBuilders.SharedKeyBuilder(new AtSign("@alice"), new AtSign("@bob"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        LlookupVerbBuilder builder = new LlookupVerbBuilder();
+        builder.with(key, LlookupVerbBuilder.Type.METADATA);
+
+        assertThat(builder.build(), equalTo("llookup:meta:@bob:test.testns@alice"));
+    }
+
+    @Test
 	public void lookupVerbBuilderTest() {
 		LookupVerbBuilder builder;
 		String command;
@@ -331,7 +406,19 @@ public class VerbBuildersTest {
 		assertEquals("lookup:meta:test@sharedwith", command);
 	}
 
-	@Test
+    @Test
+    public void testLookupVerbBuilderForSharedKeyWithNamespace() {
+        SharedKey key = new KeyBuilders.SharedKeyBuilder(new AtSign("@alice"), new AtSign("@bob"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        LookupVerbBuilder builder = new LookupVerbBuilder();
+        builder.with(key, LookupVerbBuilder.Type.METADATA);
+
+        assertThat(builder.build(), equalTo("lookup:meta:test.testns@bob"));
+    }
+
+    @Test
 	public void plookupVerbBuilderTest() {
 		PlookupVerbBuilder builder;
 		String command;
@@ -399,7 +486,20 @@ public class VerbBuildersTest {
 		assertEquals("plookup:bypassCache:true:all:publickey@alice", command);
 	}
 
-	@Test
+    @Test
+    public void testPlookupVerbBuilderForPublicKeyWithNamespace() {
+        PublicKey key = new KeyBuilders.PublicKeyBuilder(new AtSign("@alice"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        PlookupVerbBuilder builder = new PlookupVerbBuilder();
+        builder.with(key, PlookupVerbBuilder.Type.METADATA);
+
+        assertThat(builder.build(), equalTo("plookup:meta:test.testns@alice"));
+    }
+
+
+    @Test
 	public void deleteVerbBuilderTest() {
 		DeleteVerbBuilder builder;
 		String command;
@@ -496,7 +596,43 @@ public class VerbBuildersTest {
 
 	}
 
-	@Test
+    @Test
+    public void testDeleteVerbBuilderForPublicKeyWithNamespace() {
+        PublicKey key = new KeyBuilders.PublicKeyBuilder(new AtSign("@alice"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        DeleteVerbBuilder builder = new DeleteVerbBuilder();
+        builder.with(key);
+
+        assertThat(builder.build(), equalTo("delete:public:test.testns@alice"));
+    }
+
+    @Test
+    public void testDeleteVerbBuilderForSelfKeyWithNamespace() {
+        SelfKey key = new KeyBuilders.SelfKeyBuilder(new AtSign("@alice"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        DeleteVerbBuilder builder = new DeleteVerbBuilder();
+        builder.with(key);
+
+        assertThat(builder.build(), equalTo("delete:test.testns@alice"));
+    }
+
+    @Test
+    public void testDeleteVerbBuilderForSharedKeyWithNamespace() {
+        SharedKey key = new KeyBuilders.SharedKeyBuilder(new AtSign("@alice"), new AtSign("@bob"))
+            .key("test")
+            .namespace("testns")
+            .build();
+        DeleteVerbBuilder builder = new DeleteVerbBuilder();
+        builder.with(key);
+
+        assertThat(builder.build(), equalTo("delete:@bob:test.testns@alice"));
+    }
+
+    @Test
 	public void scanVerbBuilderTest() {
 
 		// Test not setting any parameters


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed the bugs in VerbBuilders.java. The with() method for the builders for update,delete,lookup,llookup and plookup was failing to marshall the atKey namespace

**- How I did it**
changed the builder methods to invoke getFullyQualifiedKeyName(). this appends the namespace to the key name.

**- How to verify it**
I created new unit tests for each of the builders.

**- Description for the changelog**
fix: ensure atkey namespace is correctly marshalled for update, delete, lookup, llookup and plookup
