### PR TITLE
fix: enhance KeyStringUtil so that it parses namespaces

### DIFF
--- a/at_client/src/main/java/org/atsign/client/util/KeyStringUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/KeyStringUtil.java
@@ -1,6 +1,13 @@
 package org.atsign.client.util;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.atsign.client.util.Preconditions.checkNotNull;
+
 public class KeyStringUtil {
+
+    private static final Pattern NAMESPACE_QUALIFIED_KEY_NAME = Pattern.compile("^(?!shared_key)(.+)\\.([^.]+)$");
 
     public enum KeyType {
         PUBLIC_KEY, // PublicKey
@@ -97,7 +104,8 @@ public class KeyStringUtil {
     }
 
     /**
-     * Given the fullKeyName, this method will evaluate all of the properties that can be exactracted from the fullKeyName. Example: fullKeyName "test@bob" will evaluate sharedBy to be "@bob" and keyName to be "test"
+     * Given the fullKeyName, this method will evaluate all of the properties that can be exactracted from the
+     * fullKeyName. Example: fullKeyName "test@bob" will evaluate sharedBy to be "@bob" and keyName to be "test"
      * @param fullKeyName the fullKeyName to be evaluated (e.g. "test@bob")
      */
     private void _evaluate(String fullKeyName) {
@@ -118,16 +126,6 @@ public class KeyStringUtil {
         // 5 == {"_latestnotificationid.fourballcorporate9@smoothalligator"} [len 1]
         // 6 == {"shared_key.wildgreen@smoothalligator"} [len 1]
         
-
-        // all keys may have a namespace [uncomment here to add partial namespace support]
-        // if(fullKeyName.contains(".")) {
-        //     String[] split2 = fullKeyName.split("\\.");
-        //     // atconnections.wildgreen.smoothalligator.at_contact.mospherepro@smoothalligator
-        //     if(split2.length == 1) {
-        //         String[] split3 = split2[1].split("@");
-        //         _namespace = split3[0];
-        //     }
-        // }
 
         if(split1.length > 1) {
             // must be scenarios 1, 2, 3, 4, 
@@ -156,8 +154,8 @@ public class KeyStringUtil {
             // 2 == {"publickey", "denise"}
             // 3 == {"shared_key", "smoothalligator"}
             // 4 == {"shared_key", "abbcservicesinc"}
-            _keyName = split2[0];
-            _sharedBy = split2[1];
+            _keyName = checkNotNull(split2[0], "key name is null");
+            _sharedBy = checkNotNull(split2[1], "shared by is null");
 
             // PublicKey and SharedKey can be cacheable!
             if(split1[0].equals("cached")) {
@@ -180,18 +178,21 @@ public class KeyStringUtil {
             String[] split2 = split1[0].split("@");
             // 5 == {"_latestnotificationid.fourballcorporate9", "smoothalligator"}
             // 6 == {"shared_key.wildgreen", "smoothalligator"}
-            _keyName = split2[0];
-            _sharedBy = split2[1];
+            _keyName = checkNotNull(split2[0], "key name is null");
+            _sharedBy = checkNotNull(split2[1], "shared by is null");
 
-            if(_keyName.startsWith("shared_key")) {
-                // SelfKey with _keyName (like `shared_key.bob@alice`) are keys with no namespace
-                _namespace = null;
-            }
+        }
+
+        Matcher matcher = NAMESPACE_QUALIFIED_KEY_NAME.matcher(_keyName);
+        if (matcher.matches()) {
+            _keyName = matcher.group(1);
+            _namespace = matcher.group(2);
+        } else {
+            _namespace = null;
         }
 
         if(_sharedBy != null) _sharedBy = "@" + _sharedBy; // add atSign in front
         if(_sharedWith != null) _sharedWith = "@" + _sharedWith; // add atSign in front
         if(!_isHidden)  _isHidden = _keyName.startsWith("_"); 
     }
-
 }

--- a/at_client/src/main/java/org/atsign/client/util/Preconditions.java
+++ b/at_client/src/main/java/org/atsign/client/util/Preconditions.java
@@ -1,0 +1,11 @@
+package org.atsign.client.util;
+
+public class Preconditions {
+
+    public static <T> T checkNotNull(T instance, String message) {
+        if (instance == null) {
+            throw new RuntimeException(message);
+        }
+        return instance;
+    }
+}

--- a/at_client/src/test/java/org/atsign/common/KeyStringUtilTest.java
+++ b/at_client/src/test/java/org/atsign/common/KeyStringUtilTest.java
@@ -1,5 +1,7 @@
 package org.atsign.common;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 
 import org.atsign.client.util.KeyStringUtil;
@@ -331,8 +333,8 @@ public class KeyStringUtilTest {
         String KEY_NAME = "atconnections.hacktheleague.smoothalligator.at_contact.mospherepro.hacktheleague@smoothalligator";
         KeyStringUtil keyStringUtil = new KeyStringUtil(KEY_NAME);
         assertEquals("atconnections.hacktheleague.smoothalligator.at_contact.mospherepro.hacktheleague@smoothalligator", keyStringUtil.getFullKeyName());
-        assertEquals("atconnections.hacktheleague.smoothalligator.at_contact.mospherepro.hacktheleague", keyStringUtil.getKeyName());
-        assertEquals(null, keyStringUtil.getNamespace());
+        assertEquals("atconnections.hacktheleague.smoothalligator.at_contact.mospherepro", keyStringUtil.getKeyName());
+        assertEquals("hacktheleague", keyStringUtil.getNamespace());
 
     }
 
@@ -445,13 +447,56 @@ public class KeyStringUtilTest {
         String KEY_NAME = "atconnections.abbcservicesinc.smoothalligator.at_contact.mospherepro.abbcservicesinc@smoothalligator";
         KeyStringUtil keyStringUtil = new KeyStringUtil(KEY_NAME);
         assertEquals("atconnections.abbcservicesinc.smoothalligator.at_contact.mospherepro.abbcservicesinc@smoothalligator", keyStringUtil.getFullKeyName());
-        assertEquals("atconnections.abbcservicesinc.smoothalligator.at_contact.mospherepro.abbcservicesinc", keyStringUtil.getKeyName());
-        assertEquals(null, keyStringUtil.getNamespace());
+        assertEquals("atconnections.abbcservicesinc.smoothalligator.at_contact.mospherepro", keyStringUtil.getKeyName());
+        assertEquals("abbcservicesinc", keyStringUtil.getNamespace());
         assertEquals(KeyType.SELF_KEY, keyStringUtil.getKeyType());
         assertEquals("@smoothalligator", keyStringUtil.getSharedBy());
         assertEquals(null, keyStringUtil.getSharedWith());
         assertEquals(false, keyStringUtil.isCached());
         assertEquals(false, keyStringUtil.isHidden());
-        assertEquals(null, keyStringUtil.getNamespace());
     }
+
+    @Test
+    public void testGetNamespaceReturnsNullForKeyStringsWithNoNamespace() {
+        assertNamespace("public:location@alice", null);
+        assertNamespace("selfkey1@alice", null);
+        assertNamespace("@bob:phone@alice", null);
+
+        assertNamespace("public:_hiddenlocation@alice", null);
+        assertNamespace("_hiddenselfkey1@alice", null);
+        assertNamespace("@bob:__hiddenphone@alice", null);
+
+        assertNamespace("cached:@bob:phone@alice", null);
+    }
+
+    @Test
+    public void testGetNamespaceReturnsNullForReservedSharedKeyPrefix() {
+        assertNamespace("shared_key.bob@alice", null);
+    }
+
+    @Test
+    public void testGetNamespaceReturnsNamespaceForKeyStringWithNamespace() {
+        assertNamespace("public:location.ns@alice", "ns");
+        assertNamespace("public:a.location.ns@alice", "ns");
+        assertNamespace("a.b.selfkey1.ns@alice", "ns");
+        assertNamespace("@bob:a.phone.ns@alice", "ns");
+        assertNamespace("@bob:a.b.c.phone.ns@alice", "ns");
+
+        assertNamespace("public:_a.hiddenlocation.ns@alice", "ns");
+        assertNamespace("_a.hiddenselfkey1.ns@alice", "ns");
+        assertNamespace("@bob:__a.b.hiddenphone.ns@alice", "ns");
+    }
+
+    private static void assertNamespace(String fullKeyName, String expected) {
+        KeyStringUtil util = new KeyStringUtil(fullKeyName);
+        assertThat(util.getNamespace(), equalTo(expected));
+    }
+
+    private static void assertGetKeyNameAndGetNamespace(String fullKeyName, String expectedKeyName, String expectedNamespace) {
+        KeyStringUtil util = new KeyStringUtil(fullKeyName);
+        assertThat(util.getKeyName(), equalTo(expectedKeyName));
+        assertThat(util.getNamespace(), equalTo(expectedNamespace));
+    }
+
+
 }


### PR DESCRIPTION
**- What I did**
Enhanced KeyStringUtil._evalute() method, this is invoked by the constructor and decodes the full key name string into cached values for the getters.

**- How I did it**
At the end of the existing parsing code, I added code looks for a namespace qualified key name using a regex.
I removed a commented out section that claims to add partial support for namespaces.
 
**- How to verify it**
I modified the existing tests that were incorrectly asserting the wrong behaviour.
I added new tests that specifically focus on the getNamespaces behaviour.

**- Description for the changelog**
fix: namespace parsing in KeyStringUtil which is used in AtClient.getKeys