### PR TITLE
fix: update maven deploy workflow to upload to central (as ossrh is retired)

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -1,13 +1,13 @@
 # This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
 # For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
 
-name: Maven Deploy `at_client` to Nexus OSSRH
+name: Maven Deploy `at_client` to Central Portal
 
 on:
   push:
     branches:
       - trunk
-  
+
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
@@ -24,15 +24,11 @@ jobs:
       with:
         java-version: '8'
         distribution: 'adopt'
-        server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
-        server-username: "MAVEN_USERNAME" # env variable for username in deploy
-        server-password: "MAVEN_PASSWORD" # env variable for token in deploy
+        server-id: central # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: "CENTRAL_USERNAME" # env variable for username in deploy
+        server-password: "CENTRAL_TOKEN" # env variable for token in deploy
         gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import
         gpg-passphrase: "GPG_PASSPHRASE" # env variable for GPG private key passphrase
-      env:
-        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-        MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
     - name: Print folder
       run: ls -al .
@@ -41,15 +37,13 @@ jobs:
       continue-on-error: true
       run: cat ~/.m2/settings.xml
 
-    - name: Publish to Apache Maven Central
+    - name: Publish to Central
       run: |
         mvn \
-        install \
         deploy \
         --batch-mode \
         --no-transfer-progress \
-        -Dgpg.skip=false
       env:
-        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-        MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+        CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/README.md
+++ b/README.md
@@ -14,19 +14,27 @@ to work with the atPlatform from Java code.
 The Java SDK can be added to your project through a compiled JAR or by Maven!
 
 ```xml
-<repositories>
+  <repositories>
     <repository>
-        <id>ossrh</id>
-        <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
     </repository>
-</repositories>
-<dependencies>
-  <dependency>
-      <groupId>io.github.atsign-foundation</groupId>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.atsign</groupId>
       <artifactId>at_client</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>0.0.1-SNAPSHOT</version>
     </dependency>
-</dependencies>
+  </dependencies>
 ```
 
 ## Getting Started

--- a/at_client/pom.xml
+++ b/at_client/pom.xml
@@ -1,29 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<name>${project.groupId}:${project.artifactId}</name>
-	<description>Core atPlatform Java dependency.</description>
-	<url>https://github.com/atsign-foundation/at_java</url>
+  <groupId>org.atsign</groupId>
+  <artifactId>at_client</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
 
-	<!-- <groupId>org.atsign</groupId> -->
-	<groupId>io.github.atsign-foundation</groupId>
-	<artifactId>at_client</artifactId>
-	<version>1.0-SNAPSHOT</version>
+  <name>at_client</name>
+	<description>atsign Java client SDK</description>
+	<url>https://github.com/atsign-foundation/at_java</url>
 
 	<properties>
 		<maven.compiler.source>8</maven.compiler.source>
 		<maven.compiler.target>8</maven.compiler.target>
 		<maven.compiler.showWarnings>true</maven.compiler.showWarnings>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<skipTests>false</skipTests>
-		<skipUnitTests>${skipTests}</skipUnitTests>
-		<skipIntegrationTests>${skipTests}</skipIntegrationTests>
-		<gpg.skip>true</gpg.skip>
+    <skipTests>false</skipTests>
+    <skipUnitTests>${skipTests}</skipUnitTests>
+    <skipIntegrationTests>${skipTests}</skipIntegrationTests>
 
-		<version.cucumber>7.14.0</version.cucumber>
-		<version.at_demo_data>1.2.0</version.at_demo_data>
-	</properties>
+    <version.cucumber>7.14.0</version.cucumber>
+    <version.at_demo_data>1.2.0</version.at_demo_data>
+  </properties>
 
 	<licenses>
 		<license>
@@ -33,31 +32,13 @@
 	</licenses>
 
 	<developers>
-		<developer>
-			<name>Jeremy Tubongbanua</name>
-			<email>jeremy.tubongbanua@atsign.com</email>
-			<organization>Atsign</organization>
-			<organizationUrl>https://atsign.com</organizationUrl>
-		</developer>
-		<developer>
-			<name>Tyler Trott</name>
-			<email>tyler.trott@atsign.com</email>
-			<organization>Atsign</organization>
-			<organizationUrl>https://atsign.com</organizationUrl>
-		</developer>
-		<!-- add yourself here if you would want -->
+    <developer>
+      <name>atsign</name>
+      <email>maven@atsign.com</email>
+      <organization>atsign</organization>
+      <organizationUrl>https://atsign.com</organizationUrl>
+    </developer>
 	</developers>
-
-	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
 
 	<scm>
 		<connection>scm:git:git://github.com/atsign-foundation/at_java.git</connection>
@@ -69,22 +50,7 @@
 		<plugins>
 
 			<plugin>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>install</phase>
-						<goals>
-							<goal>copy-dependencies</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${project.build.directory}/lib</outputDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-
-			<plugin>
+        <!-- download dart_demo_data package which contains key files and secrets required by the tests -->
 				<groupId>com.googlecode.maven-download-plugin</groupId>
 				<artifactId>download-maven-plugin</artifactId>
 				<version>1.6.8</version>
@@ -131,99 +97,85 @@
 					<skipTests>${skipUnitTests}</skipTests>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.0.0-M7</version>
-				<configuration>
-					<skipTests>${skipIntegrationTests}</skipTests>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M7</version>
+        <configuration>
+          <skipTests>${skipIntegrationTests}</skipTests>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
-			<!-- sources attachments for maven dependency -->
-			<plugin>
+      <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.2.1</version>
+        <version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
+            <goals>
+							<goal>jar</goal>
 						</goals>
 					</execution>
 				</executions>
 			</plugin>
 
-			<!-- java doc for maven dependency -->
-			<!-- <plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
-				<executions>
-				  <execution>
-					<id>attach-javadocs</id>
-					<goals>
-					  <goal>jar</goal>
-					</goals>
-				  </execution>
-				</executions>
-			  </plugin> -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.6.3</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <failOnError>false</failOnError>
+              <additionalOptions>-Xdoclint:none</additionalOptions>
+              <quiet>true</quiet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
-			<!-- Nexus Staging Maven Plugin for Deployment and Release -->
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
-				</configuration>
-			</plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
-			<!-- The Maven GPG plugin is used to sign the components with the following configuration. -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.0.1</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-						<configuration>
-							<!-- Prevent gpg from using pinentry programs https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#extra-setup-for-pomxml -->
-							<gpgArguments>
-								<arg>--pinentry-mode</arg>
-								<arg>loopback</arg>
-							</gpgArguments>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.9.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+        </configuration>
+      </plugin>
 
-		</plugins>
-
-		<resources>
-			<resource>
-				<directory>src/main/resources</directory>
-			</resource>
-		</resources>
+    </plugins>
 	</build>
 
-	<dependencies>
+  <dependencies>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>


### PR DESCRIPTION

**- What I did**
Fixed the github action in at_java so that a SNAPSHOT of the latest version is now published to [central portal snapshots](https://central.sonatype.com/repository/maven-snapshots). ossrh is now retired.
The artifact now has groupId of **org.atsign**
The initial version is **0.0.1-SNAPSHOT**

fixes #287

**- How I did it**
Cleaned up the pom.xml as per the maven central guidelines
Adjusted the maven deploy-workflow.yml so that central server is created in settings.xml and credentials for central are used
Removed the redundant *install* mvn goal (deploy will install)


**- How to verify it**
Create a simple project java project and verify that you can resolve the dependencies, for example this pom.xml
~~~
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>

  <groupId>org.example</groupId>
  <artifactId>untitled</artifactId>
  <version>1.0-SNAPSHOT</version>

  <properties>
    <maven.compiler.source>18</maven.compiler.source>
    <maven.compiler.target>18</maven.compiler.target>
    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
  </properties>

  <repositories>
    <repository>
      <name>Central Portal Snapshots</name>
      <id>central-portal-snapshots</id>
      <url>https://central.sonatype.com/repository/maven-snapshots</url>
      <releases>
        <enabled>false</enabled>
      </releases>
      <snapshots>
        <enabled>true</enabled>
      </snapshots>
    </repository>
  </repositories>

  <dependencies>
    <dependency>
      <groupId>org.atsign</groupId>
      <artifactId>at_client</artifactId>
      <version>0.0.1-SNAPSHOT</version>
    </dependency>
  </dependencies>
</project>
~~~
this command
~~~
mvn compile
~~~
should succeed and you should see this...
~~~
[INFO] Building untitled 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central-portal-snapshots: https://central.sonatype.com/repository/maven-snapshots/org/atsign/at_client/0.0.1-SNAPSHOT/maven-metadata.xml
Downloaded from central-portal-snapshots: https://central.sonatype.com/repository/maven-snapshots/org/atsign/at_client/0.0.1-SNAPSHOT/maven-metadata.xml (2.0 kB at 1.6 kB/s)
Downloading from central-portal-snapshots: https://central.sonatype.com/repository/maven-snapshots/org/atsign/at_client/0.0.1-SNAPSHOT/at_client-0.0.1-20260127.155743-7.pom
Downloaded from central-portal-snapshots: https://central.sonatype.com/repository/maven-snapshots/org/atsign/at_client/0.0.1-SNAPSHOT/at_client-0.0.1-20260127.155743-7.pom (7.2 kB at 8.3 kB/s)
Downloading from central-portal-snapshots: https://central.sonatype.com/repository/maven-snapshots/org/atsign/at_client/0.0.1-SNAPSHOT/at_client-0.0.1-20260127.155743-7.jar
Downloaded from central-portal-snapshots: https://central.sonatype.com/repository/maven-snapshots/org/atsign/at_client/0.0.1-SNAPSHOT/at_client-0.0.1-20260127.155743-7.jar (163 kB at 109 kB/s)
~~~
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fixes artifact publish for at_client
