### PR TITLE
fix: removed direct output to stderr and stdout in core library code

### DIFF
--- a/at_client/pom.xml
+++ b/at_client/pom.xml
@@ -115,6 +115,17 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
@@ -158,11 +169,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>

--- a/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/clients/AtClientImpl.java
@@ -8,7 +8,6 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -18,6 +17,7 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 
+import lombok.extern.slf4j.Slf4j;
 import org.atsign.client.api.AtClient;
 import org.atsign.client.api.AtEvents.AtEventBus;
 import org.atsign.client.api.AtEvents.AtEventListener;
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @see org.atsign.client.api.AtClient
  */
 @SuppressWarnings({"RedundantThrows", "unused"})
+@Slf4j
 public class AtClientImpl implements AtClient {
   static final ObjectMapper json = new ObjectMapper();
 
@@ -125,8 +126,7 @@ public class AtClientImpl implements AtClient {
                 EncryptionUtil.rsaDecryptFromBase64(sharedSharedKeyEncryptedValue, keys.getEncryptPrivateKey());
             keys.put(sharedSharedKeyName, sharedKeyDecryptedValue);
           } catch (Exception e) {
-            System.err.println(OffsetDateTime.now() + ": caught exception " + e
-                + " while decrypting received shared key " + sharedSharedKeyName);
+            log.error("caught exception {} while decrypting received shared key {}", e, sharedSharedKeyName);
           }
         }
         break;
@@ -149,8 +149,7 @@ public class AtClientImpl implements AtClient {
             newEventData.put("decryptedValue", decryptedValue);
             eventBus.publishEvent(decryptedUpdateNotification, newEventData);
           } catch (Exception e) {
-            System.err.println(OffsetDateTime.now() + ": caught exception " + e
-                + " while decrypting received data with key name [" + key + "]");
+            log.error("caught exception {} while decrypting received data with key name [{}]", e, key);
           }
         }
         break;

--- a/at_client/src/main/java/org/atsign/client/api/impl/connections/AtConnectionBase.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/connections/AtConnectionBase.java
@@ -8,6 +8,7 @@ import java.util.Scanner;
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
 
+import lombok.extern.slf4j.Slf4j;
 import org.atsign.client.api.AtConnection;
 import org.atsign.client.api.AtEvents;
 import org.atsign.common.AtException;
@@ -15,6 +16,7 @@ import org.atsign.common.AtException;
 /**
  * @see org.atsign.client.api.AtConnection
  */
+@Slf4j
 public abstract class AtConnectionBase implements AtConnection {
   private final String url;
 
@@ -102,7 +104,7 @@ public abstract class AtConnectionBase implements AtConnection {
     }
     connected = false;
     try {
-      System.err.println(this.getClass().getSimpleName() + " disconnecting");
+      log.debug("disconnecting from {}:{}", host, port);
       socket.close();
       socketScanner.close();
       socketWriter.close();
@@ -118,9 +120,11 @@ public abstract class AtConnectionBase implements AtConnection {
       return;
     }
     SocketFactory sf = SSLSocketFactory.getDefault();
+    log.debug("connecting to {}:{}...", host, port);
     this.socket = sf.createSocket(host, port);
     this.socketWriter = new PrintWriter(socket.getOutputStream());
     this.socketScanner = new Scanner(socket.getInputStream());
+    log.debug("connected to {}:{}", host, port);
 
     if (authenticator != null) {
       authenticator.authenticate(this);
@@ -148,14 +152,14 @@ public abstract class AtConnectionBase implements AtConnection {
       socketWriter.flush();
 
       if (verbose) {
-        System.out.println("\tSENT: " + command.trim());
+        log.info("SENT: {}", command);
       }
 
       if (readTheResponse) {
         // Responses are always terminated by newline
         String rawResponse = socketScanner.nextLine();
         if (verbose) {
-          System.out.println("\tRCVD: " + rawResponse);
+          log.info("RCVD: {}", rawResponse);
         }
 
         return parseRawResponse(rawResponse);
@@ -166,12 +170,12 @@ public abstract class AtConnectionBase implements AtConnection {
       disconnect();
 
       if (retryOnException) {
-        System.err.println("\tCaught exception " + first + " : reconnecting");
+        log.error("Caught exception {} : reconnecting", first.toString());
         try {
           connect();
           return executeCommand(command, false, true);
         } catch (Exception second) {
-          second.printStackTrace(System.err);
+          log.error("failed on retry", second);
           throw new IOException("Failed to reconnect after original exception " + first + " : ", second);
         }
       } else {

--- a/at_client/src/main/java/org/atsign/client/api/impl/connections/AtMonitorConnection.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/connections/AtMonitorConnection.java
@@ -11,6 +11,7 @@ import static org.atsign.client.api.AtEvents.AtEventType.updateNotification;
 
 import java.util.HashMap;
 
+import lombok.extern.slf4j.Slf4j;
 import org.atsign.common.AtSign;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  *
  */
+@Slf4j
 public class AtMonitorConnection extends AtSecondaryConnection implements Runnable {
   private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -68,7 +70,7 @@ public class AtMonitorConnection extends AtSecondaryConnection implements Runnab
           if (!isRunning() || lastHeartbeatSentTime - lastHeartbeatAckTime >= heartbeatIntervalMillis) {
             try {
               // heartbeats have stopped being acked
-              System.err.println("Monitor heartbeats not being received");
+              log.error("Monitor heartbeats not being received");
               stopMonitor();
               long waitStartTime = System.currentTimeMillis();
               while (isRunning() && System.currentTimeMillis() - waitStartTime < 5000) {
@@ -80,12 +82,11 @@ public class AtMonitorConnection extends AtSecondaryConnection implements Runnab
                 }
               }
               if (isRunning()) {
-                System.err.println("Monitor thread has not stopped, but going to start another one anyway");
+                log.error("Monitor thread has not stopped, but going to start another one anyway");
               }
               startMonitor();
             } catch (Exception e) {
-              System.err.println("Monitor restart failed " + e);
-              e.printStackTrace(System.err);
+              log.error("Monitor restart failed", e);
             }
           } else {
             if (System.currentTimeMillis() - lastHeartbeatSentTime > heartbeatIntervalMillis) {
@@ -121,7 +122,7 @@ public class AtMonitorConnection extends AtSecondaryConnection implements Runnab
         try {
           connect();
         } catch (Exception e) {
-          System.err.println("startMonitor failed to connect to secondary : " + e.getMessage());
+          log.error("startMonitor failed to connect to secondary : {}", e.getMessage());
           running = false;
           return false;
         }
@@ -162,7 +163,7 @@ public class AtMonitorConnection extends AtSecondaryConnection implements Runnab
         what = "read from connection";
         String response = parseRawResponse(socketScanner.nextLine());
         if (verbose) {
-          System.out.println("\tRCVD (MONITOR): " + response);
+          log.info("RCVD (MONITOR): {}", response);
         }
         AtEventType eventType;
         HashMap<String, Object> eventData = new HashMap<>();
@@ -227,7 +228,7 @@ public class AtMonitorConnection extends AtSecondaryConnection implements Runnab
 
           }
         } catch (Exception e) {
-          System.err.println("" + e);
+          log.error("monitor exception : {}", e.toString());
           eventType = monitorException;
           eventData.put("key", "__monitorException__");
           eventData.put("value", response);
@@ -235,16 +236,13 @@ public class AtMonitorConnection extends AtSecondaryConnection implements Runnab
         }
         eventBus.publishEvent(eventType, eventData);
       }
-      System.err.println("Monitor ending normally - shouldBeRunning is " + isShouldBeRunning());
+      log.info("Monitor ending normally - shouldBeRunning is {}", isShouldBeRunning());
     } catch (Exception e) {
       if (!isShouldBeRunning()) {
-        System.err.println("shouldBeRunning is false, and monitor has stopped OK. Exception was : " + e.getMessage());
+        log.info("shouldBeRunning is false, and monitor has stopped OK. Exception was : {}", e.getMessage());
       } else {
-        String message = "Monitor failed to " + what + " : " + e.getMessage();
-        System.err.println(message);
-        e.printStackTrace(System.err);
-
-        System.err.println("Monitor ending. Monitor heartbeat thread should restart the monitor shortly");
+        log.error("Monitor failed to {}", what, e);
+        log.info("Monitor ending. Monitor heartbeat thread should restart the monitor shortly");
         disconnect();
       }
     } finally {

--- a/at_client/src/main/java/org/atsign/client/api/impl/events/SimpleAtEventBus.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/events/SimpleAtEventBus.java
@@ -1,5 +1,7 @@
 package org.atsign.client.api.impl.events;
 
+import lombok.extern.slf4j.Slf4j;
+
 import static org.atsign.client.api.AtEvents.AtEventBus;
 import static org.atsign.client.api.AtEvents.AtEventListener;
 import static org.atsign.client.api.AtEvents.AtEventType;
@@ -14,6 +16,7 @@ import java.util.concurrent.Executors;
 /**
  *
  */
+@Slf4j
 public class SimpleAtEventBus implements AtEventBus {
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
@@ -37,10 +40,7 @@ public class SimpleAtEventBus implements AtEventBus {
           executor.submit(() -> listener.handleEvent(eventType, eventData));
         }
       } catch (Exception e) {
-        System.err.println(
-                           this.getClass().getSimpleName() + " caught exception from one of its event listeners : "
-                               + e.getMessage());
-        e.printStackTrace(System.err);
+        log.error("caught exception from one of its event listeners", e);
       }
     }
     return listenerCount;

--- a/at_client/src/main/java/org/atsign/client/api/impl/secondaries/RemoteSecondary.java
+++ b/at_client/src/main/java/org/atsign/client/api/impl/secondaries/RemoteSecondary.java
@@ -6,6 +6,7 @@ import static org.atsign.client.api.AtEvents.AtEventType;
 import java.io.IOException;
 import java.util.Map;
 
+import lombok.extern.slf4j.Slf4j;
 import org.atsign.client.api.AtConnectionFactory;
 import org.atsign.client.api.AtKeys;
 import org.atsign.client.api.Secondary;
@@ -22,6 +23,7 @@ import org.atsign.common.exceptions.AtUnknownResponseException;
 /**
  * @see org.atsign.client.api.Secondary
  */
+@Slf4j
 public class RemoteSecondary implements Secondary {
 
   private final AtConnectionFactory connectionFactory;
@@ -173,8 +175,7 @@ public class RemoteSecondary implements Secondary {
         monitorConnection.startMonitor();
       }
     } catch (Exception e) {
-      System.err.println("SEVERE: failed to " + what + " : " + e.getMessage());
-      e.printStackTrace(System.err);
+      log.error("SEVERE: failed to {}", what, e);
     }
   }
 
@@ -189,8 +190,7 @@ public class RemoteSecondary implements Secondary {
         monitorConnection.stopMonitor();
       }
     } catch (Exception e) {
-      System.err.println("SEVERE: failed to " + what + " : " + e.getMessage());
-      e.printStackTrace(System.err);
+      log.error("SEVERE: failed to {}", what, e);
     }
   }
 }

--- a/at_client/src/main/java/org/atsign/client/cli/Activate.java
+++ b/at_client/src/main/java/org/atsign/client/cli/Activate.java
@@ -438,7 +438,6 @@ public class Activate extends AbstractCli<Activate> implements Callable<Integer>
   }
 
   private EnrollmentId enroll(AtSecondaryConnection connection, AtKeys keys) throws Exception {
-    System.out.println(keys.getApkamSymmetricKey());
     Map<String, Object> args = toObjectMap("appName", appName,
                                            "deviceName", deviceName,
                                            "apkamPublicKey", keys.getApkamPublicKey(),

--- a/at_client/src/main/java/org/atsign/client/util/ByteUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/ByteUtil.java
@@ -1,27 +1,25 @@
 package org.atsign.client.util;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.nio.charset.StandardCharsets;
 
+@Slf4j
 public class ByteUtil {
-  public static String convert(byte[] data) { // Method to convert byte[] array to string
+  public static String convert(byte[] data) {
     try {
-      String st = new String(data, StandardCharsets.UTF_8); // Trying to parse the byte[] array 'data' to string
-      return st;
-    } catch (Exception e) { // In case if an error occurs while parsing the array
-      System.out.println("Error occured while parsing the data to string ");
-      e.printStackTrace(); // Printing the stack trace if any error occurs
+      return new String(data, StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      log.error("Error occurred while parsing the data to string", e);
       return null;
     }
   }
 
-  public static byte[] convert(String data) { // Method to convert String to byte[] array
+  public static byte[] convert(String data) {
     try {
-      // Gets the byte value of the string passed , iterating through character by character and stores their byte value into byte array
-      byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
-      return bytes;
+      return data.getBytes(StandardCharsets.UTF_8);
     } catch (Exception e) {
-      System.out.println("Error occured while parsing the string to byte array data");
-      e.printStackTrace();
+      log.error("Error occured while parsing the string to byte array data", e);
       return null;
     }
   }

--- a/at_client/src/main/java/org/atsign/client/util/KeysUtil.java
+++ b/at_client/src/main/java/org/atsign/client/util/KeysUtil.java
@@ -12,6 +12,7 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.TreeMap;
 
+import lombok.extern.slf4j.Slf4j;
 import org.atsign.client.api.AtKeys;
 import org.atsign.common.AtSign;
 import org.atsign.common.exceptions.AtClientConfigException;
@@ -19,6 +20,7 @@ import org.atsign.common.exceptions.AtClientConfigException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+@Slf4j
 public class KeysUtil {
 
   static private final String EMPTY_IV = Base64.getEncoder().encodeToString(new byte[16]);
@@ -64,7 +66,7 @@ public class KeysUtil {
     if (file.getParentFile() != null && !file.getParentFile().exists()) {
       Files.createDirectories(file.getParentFile().toPath());
     }
-    System.out.println("Saving keys to " + file.getAbsolutePath());
+    log.info("Saving keys to {}", file.getAbsolutePath());
 
     Files.write(file.toPath(), getAsJson(keys).getBytes(UTF_8));
   }

--- a/at_client/src/main/java/org/atsign/common/ResponseTransformers.java
+++ b/at_client/src/main/java/org/atsign/common/ResponseTransformers.java
@@ -4,10 +4,12 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
 import org.atsign.client.api.Secondary.Response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+@Slf4j
 public class ResponseTransformers {
   static final ObjectMapper mapper = new ObjectMapper();
 
@@ -39,7 +41,7 @@ public class ResponseTransformers {
         List<String> keys = mapper.readerForListOf(String.class).readValue(value.getRawDataResponse());
         return keys.stream().filter(filter).collect(Collectors.toList());
       } catch (Exception e) {
-        e.printStackTrace();
+        log.error("unexpected exception", e);
         return null;
       }
     }

--- a/at_client/src/test/java/org/atsign/client/cli/ActivateIT.java
+++ b/at_client/src/test/java/org/atsign/client/cli/ActivateIT.java
@@ -28,12 +28,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class ActivateIT {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ActivateIT.class);
 
   private final ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
   private final ByteArrayOutputStream errBuffer = new ByteArrayOutputStream();

--- a/at_client/src/test/java/org/atsign/common/KeysUtilTest.java
+++ b/at_client/src/test/java/org/atsign/common/KeysUtilTest.java
@@ -68,7 +68,6 @@ public class KeysUtilTest {
     KeysUtil.saveKeys(testAtSign, keys);
     File expected = KeysUtil.getKeysFile(testAtSign, KeysUtil.expectedKeysFilesLocation);
     assertTrue(expected.exists());
-    System.out.println("Expected file path: " + expected.toPath().toString());
 
     // Given a correctly formatted keys file in the legacy location
     // And there is NOT a keys file in the canonical location

--- a/at_client/src/test/java/org/atsign/cucumber/helpers/Helpers.java
+++ b/at_client/src/test/java/org/atsign/cucumber/helpers/Helpers.java
@@ -1,9 +1,7 @@
 package org.atsign.cucumber.helpers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -17,12 +15,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Helpers {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(Helpers.class);
 
   public static boolean testContains(List<Map<String, String>> actualMaps,
                                      List<Map<String, String>> expectedMaps,

--- a/at_client/src/test/java/org/atsign/cucumber/steps/ActivateSteps.java
+++ b/at_client/src/test/java/org/atsign/cucumber/steps/ActivateSteps.java
@@ -19,18 +19,16 @@ import org.atsign.common.AtSign;
 import org.atsign.common.exceptions.AtClientConfigException;
 import org.atsign.cucumber.helpers.AtDemoData;
 import org.opentest4j.TestAbortedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class ActivateSteps {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ActivateSteps.class);
 
   private final AtClientContext context;
 
@@ -208,9 +206,9 @@ public class ActivateSteps {
     @Override
     public void run() {
       if (!f.delete()) {
-        LOGGER.warn("failed to delete {}", f);
+        log.warn("failed to delete {}", f);
       } else {
-        LOGGER.info("deleted {}", f);
+        log.debug("deleted {}", f);
       }
     }
   }
@@ -246,7 +244,7 @@ public class ActivateSteps {
             .forEach(id -> revokeDeleteNoThrow(connection, id));
         revokeDeleteNoThrow(connection, onboardEnrollmentId);
       } catch (Exception e) {
-        LOGGER.error("teardown for {} failed : {}", atSign, e.getMessage());
+        log.error("teardown for {} failed : {}", atSign, e.getMessage());
       }
     }
 
@@ -259,45 +257,45 @@ public class ActivateSteps {
 
     protected void deleteKeyNoThrow(AtSecondaryConnection connection, String key) {
       try {
-        LOGGER.info("teardown for {} deleting key {}", connection.getAtSign(), key);
+        log.debug("teardown for {} deleting key {}", connection.getAtSign(), key);
         deleteKey(connection, key);
       } catch (Exception e) {
-        LOGGER.error("teardown for {} failed to delete key {} in onboarded server : {}",
-                     connection.getAtSign(), key, e.getMessage());
+        log.error("teardown for {} failed to delete key {} in onboarded server : {}",
+                  connection.getAtSign(), key, e.getMessage());
       }
     }
 
     private void deleteNoThrow(AtSecondaryConnection connection, EnrollmentId id) {
       try {
-        LOGGER.info("teardown for {} deleting enroll request {}", id);
+        log.debug("teardown for {} deleting enroll request {}", id);
         delete(connection, id);
       } catch (Exception e) {
-        LOGGER.error("teardown for {} failed to enroll delete {} in onboarded server : {}",
-                     connection.getAtSign(), id, e.getMessage());
+        log.error("teardown for {} failed to enroll delete {} in onboarded server : {}",
+                  connection.getAtSign(), id, e.getMessage());
       }
     }
 
     private void denyDeleteNoThrow(AtSecondaryConnection connection, EnrollmentId id) {
       try {
-        LOGGER.info("teardown for {} denying enroll request {}", connection.getAtSign(), id);
+        log.debug("teardown for {} denying enroll request {}", connection.getAtSign(), id);
         deny(connection, id);
-        LOGGER.info("teardown for {} deleting enroll request {}", connection.getAtSign(), id);
+        log.debug("teardown for {} deleting enroll request {}", connection.getAtSign(), id);
         delete(connection, id);
       } catch (Exception e) {
-        LOGGER.error("teardown for {} failed to enroll deny and delete {} in onboarded server : {}",
-                     connection.getAtSign(), id, e.getMessage());
+        log.error("teardown for {} failed to enroll deny and delete {} in onboarded server : {}",
+                  connection.getAtSign(), id, e.getMessage());
       }
     }
 
     private void revokeDeleteNoThrow(AtSecondaryConnection connection, EnrollmentId id) {
       try {
-        LOGGER.info("teardown for {} revoking enroll request {}", connection.getAtSign(), id);
+        log.debug("teardown for {} revoking enroll request {}", connection.getAtSign(), id);
         revoke(connection, id);
-        LOGGER.info("teardown for {} deleting enroll request {}", connection.getAtSign(), id);
+        log.debug("teardown for {} deleting enroll request {}", connection.getAtSign(), id);
         delete(connection, id);
       } catch (Exception e) {
-        LOGGER.error("teardown for {} failed to enroll revoke and delete {} in onboarded server : {}",
-                     connection.getAtSign(), id, e.getMessage());
+        log.error("teardown for {} failed to enroll revoke and delete {} in onboarded server : {}",
+                  connection.getAtSign(), id, e.getMessage());
       }
     }
   }

--- a/at_client/src/test/java/org/atsign/cucumber/steps/AtClientContext.java
+++ b/at_client/src/test/java/org/atsign/cucumber/steps/AtClientContext.java
@@ -6,9 +6,7 @@ import static org.atsign.client.util.Preconditions.checkNotNull;
 import static org.atsign.cucumber.helpers.Helpers.isHostPortReachable;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.typeCompatibleWith;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
@@ -31,17 +29,15 @@ import org.atsign.cucumber.helpers.AtDemoData;
 import org.atsign.virtualenv.VirtualEnv;
 import org.junit.jupiter.api.function.Executable;
 import org.opentest4j.TestAbortedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.cucumber.java.After;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class AtClientContext {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(AtClientContext.class);
 
   private static final Set<AtEvents.AtEventType> ALL_EVENT_TYPES = Collections.unmodifiableSet(
                                                                                                new HashSet<>(Arrays
@@ -275,7 +271,7 @@ public class AtClientContext {
 
   @And("pause for {long} {timeunit}")
   public void pause(long duration, TimeUnit unit) throws Exception {
-    LOGGER.info("sleeping for {} {}", duration, unit);
+    log.debug("sleeping for {} {}", duration, unit);
     Thread.sleep(unit.toMillis(duration));
   }
 
@@ -382,14 +378,14 @@ public class AtClientContext {
 
     @Override
     public void handleEvent(AtEvents.AtEventType eventType, Map<String, Object> eventData) {
-      LOGGER.info("{} received {} : {}", atSign, eventType, eventData);
+      log.debug("{} received {} : {}", atSign, eventType, eventData);
       events.add(new AtClientEvent(eventType, eventData));
     }
 
     private int clear() {
       int count = events.size();
       events.clear();
-      LOGGER.info("{} cleared {} events", atSign, count);
+      log.debug("{} cleared {} events", atSign, count);
       return count;
     }
   }
@@ -442,11 +438,11 @@ public class AtClientContext {
         .filter(this::requiresTeardown)
         .collect(Collectors.toList());
     keys.forEach(k -> deleteKeyNoThrow(client, k));
-    LOGGER.info("teardown for {} deleted {}", lookupQualifiedAtSign(client), keys);
+    log.debug("teardown for {} deleted {}", lookupQualifiedAtSign(client), keys);
     try {
       client.close();
     } catch (IOException e) {
-      LOGGER.info("teardown close for {} threw exception : {}", lookupQualifiedAtSign(client), e.getMessage());
+      log.debug("teardown close for {} threw exception : {}", lookupQualifiedAtSign(client), e.getMessage());
     }
   }
 
@@ -470,7 +466,7 @@ public class AtClientContext {
     try {
       client.executeCommand("delete:" + key, true);
     } catch (Exception e) {
-      LOGGER.error("attempt to delete {} failed : {}", key, e.getMessage());
+      log.error("attempt to delete {} failed : {}", key, e.getMessage());
     }
   }
 
@@ -479,7 +475,7 @@ public class AtClientContext {
       String json = client.getSecondary().executeCommand("scan:showHidden:true .*", true).getRawDataResponse();
       return decodeJsonListOfStrings(json);
     } catch (Exception e) {
-      LOGGER.error("failed to scan : {}", e.getMessage());
+      log.error("failed to scan : {}", e.getMessage());
       return Collections.emptyList();
     }
   }

--- a/at_client/src/test/java/org/atsign/cucumber/steps/GetAtKeysSteps.java
+++ b/at_client/src/test/java/org/atsign/cucumber/steps/GetAtKeysSteps.java
@@ -4,9 +4,7 @@ import static java.util.Arrays.asList;
 import static org.atsign.cucumber.helpers.Helpers.assertContains;
 import static org.atsign.cucumber.helpers.Helpers.toCanonicalKey;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -15,8 +13,6 @@ import org.atsign.client.api.AtClient;
 import org.atsign.common.AtSign;
 import org.atsign.common.KeyBuilders;
 import org.atsign.common.Keys;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.cucumber.datatable.DataTable;
 import io.cucumber.datatable.DataTableFormatter;
@@ -24,8 +20,6 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 
 public class GetAtKeysSteps {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(GetAtKeysSteps.class);
 
   public static final List<String> HEADINGS = asList(
                                                      "Key",

--- a/at_client/src/test/java/org/atsign/cucumber/steps/MonitorSteps.java
+++ b/at_client/src/test/java/org/atsign/cucumber/steps/MonitorSteps.java
@@ -3,9 +3,7 @@ package org.atsign.cucumber.steps;
 import static org.atsign.cucumber.helpers.Helpers.assertContains;
 import static org.atsign.cucumber.helpers.Helpers.testContains;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.testcontainers.shaded.com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
@@ -16,16 +14,12 @@ import java.util.concurrent.TimeUnit;
 import org.atsign.client.api.AtClient;
 import org.atsign.client.api.AtEvents;
 import org.atsign.common.AtSign;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.cucumber.datatable.DataTable;
 import io.cucumber.datatable.DataTableFormatter;
 import io.cucumber.java.en.Then;
 
 public class MonitorSteps {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(MonitorSteps.class);
 
   private final AtClientContext context;
 

--- a/at_client/src/test/java/org/atsign/cucumber/steps/PublicAtKeySteps.java
+++ b/at_client/src/test/java/org/atsign/cucumber/steps/PublicAtKeySteps.java
@@ -11,15 +11,11 @@ import org.atsign.client.util.KeyStringUtil;
 import org.atsign.common.AtSign;
 import org.atsign.common.KeyBuilders;
 import org.atsign.common.Keys;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
 public class PublicAtKeySteps {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(PublicAtKeySteps.class);
 
   private final AtClientContext context;
 

--- a/at_client/src/test/java/org/atsign/cucumber/steps/SelfAtKeySteps.java
+++ b/at_client/src/test/java/org/atsign/cucumber/steps/SelfAtKeySteps.java
@@ -11,15 +11,11 @@ import org.atsign.client.util.KeyStringUtil;
 import org.atsign.common.AtSign;
 import org.atsign.common.KeyBuilders;
 import org.atsign.common.Keys;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
 public class SelfAtKeySteps {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(SelfAtKeySteps.class);
 
   private final AtClientContext context;
 

--- a/at_client/src/test/java/org/atsign/cucumber/steps/SharedAtKeySteps.java
+++ b/at_client/src/test/java/org/atsign/cucumber/steps/SharedAtKeySteps.java
@@ -10,15 +10,11 @@ import org.atsign.client.util.KeyStringUtil;
 import org.atsign.common.AtSign;
 import org.atsign.common.KeyBuilders;
 import org.atsign.common.Keys;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
 public class SharedAtKeySteps {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(SharedAtKeySteps.class);
 
   private final AtClientContext context;
 

--- a/at_client/src/test/java/org/atsign/virtualenv/VirtualEnv.java
+++ b/at_client/src/test/java/org/atsign/virtualenv/VirtualEnv.java
@@ -11,22 +11,21 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ComposeContainer;
 import org.testcontainers.containers.output.OutputFrame;
 
-public class VirtualEnv {
+import lombok.extern.slf4j.Slf4j;
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(VirtualEnv.class);
+@Slf4j
+public class VirtualEnv {
 
   private static ComposeContainer CONTAINER;
 
   public static void main(String[] args) throws Exception {
     setUp();
-    LOGGER.info("sleeping for 1 hour, after which container will be torn down...");
+    log.info("sleeping for 1 hour, after which container will be torn down...");
     Thread.sleep(HOURS.toMillis(1));
-    LOGGER.info("tearing down");
+    log.info("tearing down");
     tearDown();
   }
 
@@ -58,9 +57,9 @@ public class VirtualEnv {
     };
 
     public void await(long timeout, TimeUnit unit) throws InterruptedException {
-      LOGGER.info("awaiting container log to contain {} lines that match {}...", latch.getCount(), matcher.pattern());
+      log.info("awaiting container log to contain {} lines that match {}...", latch.getCount(), matcher.pattern());
       latch.await(timeout, unit);
-      LOGGER.info("container log indicates that start up is complete");
+      log.info("container log indicates that start up is complete");
     }
 
     @Override

--- a/at_client/src/test/resources/simpleLogger.properties
+++ b/at_client/src/test/resources/simpleLogger.properties
@@ -1,0 +1,3 @@
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss

--- a/examples/src/main/java/org/atsign/examples/PublicKeyDeleteExample.java
+++ b/examples/src/main/java/org/atsign/examples/PublicKeyDeleteExample.java
@@ -1,6 +1,8 @@
 package org.atsign.examples;
 
-import java.util.concurrent.CancellationException;
+import static org.atsign.client.util.KeysUtil.loadKeys;
+
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.atsign.client.api.AtClient;
@@ -8,8 +10,6 @@ import org.atsign.common.AtException;
 import org.atsign.common.AtSign;
 import org.atsign.common.KeyBuilders;
 import org.atsign.common.Keys.PublicKey;
-
-import static org.atsign.client.util.KeysUtil.loadKeys;
 
 public class PublicKeyDeleteExample {
 
@@ -24,28 +24,21 @@ public class PublicKeyDeleteExample {
     // 2. create AtSign instance
     AtSign atSign = new AtSign(ATSIGN_STR);
 
-
     // 3. create AtClient instance using factory methods
-    AtClient atClient = null;
-    try {
-      atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE);
-    } catch (AtException e) {
+    try (AtClient atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE)) {
+
+      // 4. create public key
+      PublicKey pk = new KeyBuilders.PublicKeyBuilder(atSign).key(KEY_NAME).build();
+
+      // 5. delete the key
+      String response = atClient.delete(pk).get();
+      System.out.println(response);
+
+    } catch (AtException | IOException | InterruptedException | ExecutionException e) {
       System.err.println(e);
       e.printStackTrace();
     }
 
-    // 4. create public key
-    PublicKey pk = new KeyBuilders.PublicKeyBuilder(atSign).key(KEY_NAME).build();
-
-    // 5. delete the key
-    String response = null;
-    try {
-      response = atClient.delete(pk).get();
-    } catch (InterruptedException | ExecutionException | CancellationException e) {
-      System.err.println(e);
-      e.printStackTrace();
-    }
-    System.out.println(response);
   }
 
 }

--- a/examples/src/main/java/org/atsign/examples/PublicKeyGetBypassCacheExample.java
+++ b/examples/src/main/java/org/atsign/examples/PublicKeyGetBypassCacheExample.java
@@ -1,5 +1,6 @@
 package org.atsign.examples;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.atsign.client.api.AtClient;
@@ -24,26 +25,20 @@ public class PublicKeyGetBypassCacheExample {
     AtSign atSign = new AtSign(ATSIGN_STR);
 
     // 3. atClient factory method
-    AtClient atClient = null;
-    try {
-      atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE);
-    } catch (AtException e) {
+    try (AtClient atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE)) {
+
+      // 4. create the key
+      PublicKey pk = new KeyBuilders.PublicKeyBuilder(new AtSign("@bob")).key(KEY_NAME).build();
+
+      // 5. get the value associated with the key
+      String response = atClient.get(pk, (GetRequestOptions) new GetRequestOptions().bypassCache(true).build()).get();
+      System.out.println(response);
+
+    } catch (AtException | IOException | InterruptedException | ExecutionException e) {
       System.err.println("Failed to connect to remote server " + e);
       e.printStackTrace();
     }
 
-    // 4. create the key
-    PublicKey pk = new KeyBuilders.PublicKeyBuilder(new AtSign("@bob")).key(KEY_NAME).build();
-
-    // 5. get the value associated with the key
-    String response = null;
-    try {
-      response = atClient.get(pk, (GetRequestOptions) new GetRequestOptions().bypassCache(true).build()).get();
-    } catch (InterruptedException | ExecutionException e) {
-      System.err.println("Failed to get key " + e);
-      e.printStackTrace();
-    }
-    System.out.println(response);
 
   }
 }

--- a/examples/src/main/java/org/atsign/examples/PublicKeyGetExample.java
+++ b/examples/src/main/java/org/atsign/examples/PublicKeyGetExample.java
@@ -1,5 +1,6 @@
 package org.atsign.examples;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.atsign.client.api.AtClient;
@@ -23,26 +24,18 @@ public class PublicKeyGetExample {
     AtSign atSign = new AtSign(ATSIGN_STR);
 
     // 3. atClient factory method
-    AtClient atClient = null;
-    try {
-      atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE);
-    } catch (AtException e) {
+    try (AtClient atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE)) {
+
+      // 4. create the key
+      PublicKey pk = new KeyBuilders.PublicKeyBuilder(atSign).key(KEY_NAME).build();
+
+      // 5. get the value associated with the key
+      String response = atClient.get(pk).get();
+      System.out.println(response);
+
+    } catch (AtException | IOException | InterruptedException | ExecutionException e) {
       System.err.println("Failed to connect to remote server " + e);
       e.printStackTrace();
     }
-
-    // 4. create the key
-    PublicKey pk = new KeyBuilders.PublicKeyBuilder(atSign).key(KEY_NAME).build();
-
-    // 5. get the value associated with the key
-    String response = null;
-    try {
-      response = atClient.get(pk).get();
-    } catch (InterruptedException | ExecutionException e) {
-      System.err.println("Failed to get key " + e);
-      e.printStackTrace();
-    }
-    System.out.println(response);
-
   }
 }

--- a/examples/src/main/java/org/atsign/examples/PublicKeyPutExample.java
+++ b/examples/src/main/java/org/atsign/examples/PublicKeyPutExample.java
@@ -1,5 +1,6 @@
 package org.atsign.examples;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.atsign.client.api.AtClient;
@@ -25,26 +26,19 @@ public class PublicKeyPutExample {
     AtSign atSign = new AtSign(ATSIGN_STR);
 
     // 3. atClient factory method
-    AtClient atClient = null;
-    try {
-      atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE);
-    } catch (AtException e) {
+    try (AtClient atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE)) {
+
+      // 4. create a new public key
+      PublicKey pk = new KeyBuilders.PublicKeyBuilder(atSign).key(KEY_NAME).build();
+
+      // 5. put the key
+      String response = atClient.put(pk, VALUE).get();
+      System.out.println(response);
+
+    } catch (AtException | IOException | InterruptedException | ExecutionException e) {
       System.err.println("Failed to connect to remote server " + e);
       e.printStackTrace();
     }
-
-    // 4. create a new public key
-    PublicKey pk = new KeyBuilders.PublicKeyBuilder(atSign).key(KEY_NAME).build();
-
-    // 5. put the key
-    String response = null;
-    try {
-      response = atClient.put(pk, VALUE).get();
-    } catch (InterruptedException | ExecutionException e) {
-      System.err.println("Failed to put key " + e);
-      e.printStackTrace();
-    }
-    System.out.println(response);
   }
 
 }

--- a/examples/src/main/java/org/atsign/examples/SelfKeyDeleteExample.java
+++ b/examples/src/main/java/org/atsign/examples/SelfKeyDeleteExample.java
@@ -1,5 +1,6 @@
 package org.atsign.examples;
 
+import java.io.IOException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
@@ -25,27 +26,19 @@ public class SelfKeyDeleteExample {
     AtSign atSign = new AtSign(ATSIGN_STR);
 
     // 3. atClient factory method
-    AtClient atClient = null;
-    try {
-      atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE);
-    } catch (AtException e) {
+    try (AtClient atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE)) {
+
+      // 4. create self key
+      SelfKey sk = new KeyBuilders.SelfKeyBuilder(atSign).key(KEY_NAME).build();
+
+      // 5. delete the key
+      String response = atClient.delete(sk).get();
+      System.out.println(response);
+
+    } catch (AtException | IOException | InterruptedException | ExecutionException e) {
       System.err.println("Failed to connect to remote server " + e);
       e.printStackTrace();
     }
-
-    // 4. create self key
-    SelfKey sk = new KeyBuilders.SelfKeyBuilder(atSign).key(KEY_NAME).build();
-
-    // 5. delete the key
-    String response = null;
-    try {
-      response = atClient.delete(sk).get();
-    } catch (InterruptedException | ExecutionException | CancellationException e) {
-      System.err.println("Failed to delete key " + e);
-      e.printStackTrace();
-    }
-    System.out.println(response);
-
   }
 
 }

--- a/examples/src/main/java/org/atsign/examples/SelfKeyGetExample.java
+++ b/examples/src/main/java/org/atsign/examples/SelfKeyGetExample.java
@@ -1,5 +1,6 @@
 package org.atsign.examples;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.atsign.client.api.AtClient;
@@ -25,28 +26,20 @@ public class SelfKeyGetExample {
     AtSign atSign = new AtSign(ATSIGN_STR);
 
     // 3. atClient factory method
-    AtClient atClient = null;
-    try {
-      atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE);
-    } catch (AtException e) {
+    try (AtClient atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE)) {
+
+      // 4. create selfkey
+      SelfKey sk = new KeyBuilders.SelfKeyBuilder(atSign).key(KEY_NAME).build();
+
+      // 5. get the key
+      String response = atClient.get(sk).get();
+      System.out.println(response);
+      _printMetadata(sk.metadata);
+
+    } catch (AtException | IOException | InterruptedException | ExecutionException e) {
       System.err.println("Failed to connect to remote server " + e);
       e.printStackTrace();
     }
-
-    // 4. create selfkey
-    SelfKey sk = new KeyBuilders.SelfKeyBuilder(atSign).key(KEY_NAME).build();
-
-    // 5. get the key
-    String response = null;
-    try {
-      response = atClient.get(sk).get();
-    } catch (InterruptedException | ExecutionException e) {
-      System.err.println("Failed to get key " + e);
-      e.printStackTrace();
-    }
-    System.out.println(response);
-    _printMetadata(sk.metadata);
-
   }
 
 

--- a/examples/src/main/java/org/atsign/examples/SelfKeyPutExample.java
+++ b/examples/src/main/java/org/atsign/examples/SelfKeyPutExample.java
@@ -1,5 +1,6 @@
 package org.atsign.examples;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.atsign.client.api.AtClient;
@@ -27,27 +28,20 @@ public class SelfKeyPutExample {
     AtSign atSign = new AtSign(ATSIGN_STR);
 
     // 3. atClient factory method
-    AtClient atClient = null;
-    try {
-      atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE);
-    } catch (AtException e) {
+    try (AtClient atClient = AtClient.withRemoteSecondary(ROOT_URL, atSign, loadKeys(atSign), VERBOSE)) {
+
+      // 4. create selfkey
+      SelfKey sk = new KeyBuilders.SelfKeyBuilder(atSign).key(KEY_NAME).build();
+      sk.metadata.ttl = ttl;
+
+      // 5. put the key
+      String response = atClient.put(sk, VALUE).get();
+      System.out.println(response);
+
+    } catch (AtException | IOException | InterruptedException | ExecutionException e) {
       System.err.println("Failed to connect to remote server " + e);
       e.printStackTrace();
     }
-
-    // 4. create selfkey
-    SelfKey sk = new KeyBuilders.SelfKeyBuilder(atSign).key(KEY_NAME).build();
-    sk.metadata.ttl = ttl;
-
-    // 5. put the key
-    String response = null;
-    try {
-      response = atClient.put(sk, VALUE).get();
-    } catch (InterruptedException | ExecutionException e) {
-      System.err.println("Failed to put key " + e);
-      e.printStackTrace();
-    }
-    System.out.println(response);
   }
 
 }

--- a/examples/src/main/java/org/atsign/examples/SharedKeyDeleteExample.java
+++ b/examples/src/main/java/org/atsign/examples/SharedKeyDeleteExample.java
@@ -1,5 +1,6 @@
 package org.atsign.examples;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.atsign.client.api.AtClient;
@@ -26,26 +27,19 @@ public class SharedKeyDeleteExample {
     AtSign sharedWith = new AtSign(ATSIGN_STR_SHARED_WITH);
 
     // 3. atClient factory method
-    AtClient atClient = null;
-    try {
-      atClient = AtClient.withRemoteSecondary(ROOT_URL, sharedBy, loadKeys(sharedBy), VERBOSE);
-    } catch (AtException e) {
+    try (AtClient atClient = AtClient.withRemoteSecondary(ROOT_URL, sharedBy, loadKeys(sharedBy), VERBOSE)) {
+
+      // 4. create SharedKey instance
+      SharedKey sk = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key(KEY_NAME).build();
+
+      // 5. delete the key
+      String response = atClient.delete(sk).get();
+      System.out.println(response);
+
+    } catch (AtException | InterruptedException | ExecutionException | IOException e) {
       System.err.println("Failed to create AtClient instance " + e);
       e.printStackTrace();
     }
-
-    // 4. create SharedKey instance
-    SharedKey sk = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key(KEY_NAME).build();
-
-    // 5. delete the key
-    String response = null;
-    try {
-      response = atClient.delete(sk).get();
-    } catch (InterruptedException | ExecutionException e) {
-      System.err.println(e);
-      e.printStackTrace();
-    }
-    System.out.println(response);
   }
 
 }

--- a/examples/src/main/java/org/atsign/examples/SharedKeyGetOtherExample.java
+++ b/examples/src/main/java/org/atsign/examples/SharedKeyGetOtherExample.java
@@ -1,5 +1,6 @@
 package org.atsign.examples;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.atsign.client.api.AtClient;
@@ -25,27 +26,20 @@ public class SharedKeyGetOtherExample {
     AtSign sharedWith = new AtSign(ATSIGN_STR_SHARED_WITH); // your atSign
 
     // 3. atClient factory method
-    AtClient atClient = null;
-    try {
-      atClient = AtClient.withRemoteSecondary(ROOT_URL, sharedWith, loadKeys(sharedWith), VERBOSE); // AtClient instance created with your atSign (sharedWith)
-    } catch (AtException e) {
+    try (AtClient atClient = AtClient.withRemoteSecondary(ROOT_URL, sharedWith, loadKeys(sharedWith), VERBOSE)) {
+
+      // 4. create SharedKey instance
+      // key is sharedBy the other person and sharedWith you.
+      SharedKey sk = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key(KEY_NAME).build();
+
+      // 5. get the key
+      String response = atClient.get(sk).get();
+      System.out.println(response);
+
+    } catch (AtException | IOException | InterruptedException | ExecutionException e) {
       System.err.println("Failed to create AtClient instance " + e);
       e.printStackTrace();
     }
-
-    // 4. create SharedKey instance
-    // key is sharedBy the other person and sharedWith you.
-    SharedKey sk = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key(KEY_NAME).build();
-
-    // 5. get the key
-    String response = null;
-    try {
-      response = atClient.get(sk).get();
-    } catch (InterruptedException | ExecutionException e) {
-      System.err.println("Failed to get key " + e);
-      e.printStackTrace();
-    }
-    System.out.println(response);
   }
 
 }

--- a/examples/src/main/java/org/atsign/examples/SharedKeyGetSelfExample.java
+++ b/examples/src/main/java/org/atsign/examples/SharedKeyGetSelfExample.java
@@ -1,5 +1,6 @@
 package org.atsign.examples;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.atsign.client.api.AtClient;
@@ -25,26 +26,19 @@ public class SharedKeyGetSelfExample {
     AtSign sharedWith = new AtSign(ATSIGN_STR_SHARED_WITH);
 
     // 3. atClient factory method
-    AtClient atClient = null;
-    try {
-      atClient = AtClient.withRemoteSecondary(ROOT_URL, sharedBy, loadKeys(sharedBy), VERBOSE);
-    } catch (AtException e) {
+    try (AtClient atClient = AtClient.withRemoteSecondary(ROOT_URL, sharedBy, loadKeys(sharedBy), VERBOSE)) {
+
+      // 4. create SharedKey instance
+      SharedKey sk = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key(KEY_NAME).build();
+
+      // 5. get the key
+      String response = atClient.get(sk).get();
+      System.out.println(response);
+
+    } catch (AtException | IOException | InterruptedException | ExecutionException e) {
       System.err.println("Failed to create AtClient instance " + e);
       e.printStackTrace();
     }
-
-    // 4. create SharedKey instance
-    SharedKey sk = new KeyBuilders.SharedKeyBuilder(sharedBy, sharedWith).key(KEY_NAME).build();
-
-    // 5. get the key
-    String response = null;
-    try {
-      response = atClient.get(sk).get();
-    } catch (InterruptedException | ExecutionException e) {
-      System.err.println("Failed to get key " + e);
-      e.printStackTrace();
-    }
-    System.out.println(response);
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <version.bouncycastle>1.78.1</version.bouncycastle>
     <version.picocli>4.7.6</version.picocli>
     <version.slf4j>2.0.9</version.slf4j>
+    <version.lombok>1.18.30</version.lombok>
 
     <version.junit-jupiter>5.10.2</version.junit-jupiter>
     <version.junit-platform-suite>1.10.2</version.junit-platform-suite>
@@ -100,6 +101,13 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
         <version>${version.slf4j}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${version.lombok}</version>
+        <scope>provided</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION

**- What I did**
* Removes direct output to System.out and System.err in core library code.
* Cleanup of examples module included

**NOTE** CLI classes have NOT been modified and neither has the examples module (to keep it simple)

closes #337 

**- How I did it**
* Added project Lombok (this is a compile time library that removes the need for Java boiler plate and includes slf4j logging)
* Replaced all the instances in which the code was printing to System.out and System.err with log statements
* Replaced printStack trace statements with log statements

**- How to verify it**

**- Description for the changelog**
replaced direct output to stderr and stdout with slf4j logging in core library code
