### PR TITLE
fix: upgraded testcontainers test dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_API_VERSION: "1.52"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK 11 and maven cache
@@ -26,7 +24,7 @@ jobs:
           cache: maven
       - name: Add virtual env entry to hosts file
         run: echo "127.0.0.1    vip.ve.atsign.zone" | sudo tee -a /etc/hosts
-      - name: Echo DOCKER_API_VERSION
-        run: echo $DOCKER_API_VERSION
+      - name: Echo Docker Version
+        run: docker version
       - name: Build and run all tests
-        run: mvn -Ddocker.api.version=1.52 --batch-mode clean install
+        run: mvn --batch-mode clean install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_API_VERSION: "1.52"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK 11 and maven cache
@@ -24,5 +26,7 @@ jobs:
           cache: maven
       - name: Add virtual env entry to hosts file
         run: echo "127.0.0.1    vip.ve.atsign.zone" | sudo tee -a /etc/hosts
+      - name: Echo DOCKER_API_VERSION
+        run: echo $DOCKER_API_VERSION
       - name: Build and run all tests
-        run: mvn --batch-mode clean install
+        run: mvn -Ddocker.api.version=1.52 --batch-mode clean install

--- a/at_client/src/test/resources/docker-java.properties
+++ b/at_client/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44

--- a/at_client/src/test/resources/docker-java.properties
+++ b/at_client/src/test/resources/docker-java.properties
@@ -1,1 +1,0 @@
-api.version=1.44

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <version.hamcrest>2.2</version.hamcrest>
     <version.cucumber>7.14.0</version.cucumber>
     <version.at_demo_data>1.2.0</version.at_demo_data>
-    <version.testcontainers>1.21.3</version.testcontainers>
+    <version.testcontainers>1.21.4</version.testcontainers>
     <version.awaitility>4.2.0</version.awaitility>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <version.hamcrest>2.2</version.hamcrest>
     <version.cucumber>7.14.0</version.cucumber>
     <version.at_demo_data>1.2.0</version.at_demo_data>
-    <version.testcontainers>1.21.4</version.testcontainers>
+    <version.testcontainers>2.0.3</version.testcontainers>
     <version.awaitility>4.2.0</version.awaitility>
   </properties>
 


### PR DESCRIPTION
closes #358 

**- What I did**
The integration tests which operate against the virtual env docker container use the project testcontainers
The version we were using was unable to work with the updated version of docker in the github workflow
I upgrade the version of testcontainers

**- How I did it**
* Updated the version property in the parent pom
* Added echo of docker version to ci workflow (useful to always have this)
* Added debug logging to simpleLogger.properties (commented out but useful for any future issues)
* Added comment to VirtualEnv.java with regards to windows dev (the upgraded testcontainers will NOT work with windows desktop docker and neither can I get it to work with dockerd running in wsl. This is not critical just annoying).

**- How to verify it**
This is verified by the ci workflow for the PR

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
upgraded testcontainers version to fix github docker inter-operability