### PR TITLE
fix: incremented versions for jackson and netty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
     <coverage.branch>0.9</coverage.branch>
 
     <!-- dependency versions -->
-    <version.jackson>2.16.1</version.jackson>
+    <version.jackson>2.21.1</version.jackson>
     <version.bouncycastle>1.79</version.bouncycastle>
-    <version.netty>4.1.109.Final</version.netty>
+    <version.netty>4.2.12.Final</version.netty>
     <version.picocli>4.7.6</version.picocli>
     <version.slf4j>2.0.13</version.slf4j>
     <version.lombok>1.18.30</version.lombok>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
#closes 379

**- What I did**
Updated versions of 3rd party jars (jackson & netty)

**- How I did it**
Modified properties in parent pom

**- How to verify it**
Run a clean mvn install which will run all the unit and integration tests
Create a new intellij java project and add a dependency for 
```
    <dependency>
      <groupId>org.atsign</groupId>
      <artifactId>at_client</artifactId>
      <version>0.0.1-SNAPSHOT</version>
    </dependency>
```
No vulnerabilities should be reported

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: upgrade dependencies for jackson to 2.21.1 and netty to 4.2.12.Final