### PR TITLE
At talk for java

### DIFF
--- a/at_client/src/main/java/org/atsign/client/impl/AtClientImpl.java
+++ b/at_client/src/main/java/org/atsign/client/impl/AtClientImpl.java
@@ -52,6 +52,7 @@ public class AtClientImpl implements AtClient {
 
   private final AtSign atSign;
   private final AtKeys keys;
+  private MonitorOptions monitorOptions;
   private final Map<String, Object> config;
   private final AtCommandExecutor executor;
   private final AtEventBus eventBus;
@@ -71,16 +72,20 @@ public class AtClientImpl implements AtClient {
   @Builder
   public AtClientImpl(AtSign atSign,
                       AtKeys keys,
+                      boolean withMonitoring,
+                      MonitorOptions monitorOptions,
                       Map<String, Object> config,
                       AtCommandExecutor executor,
                       AtEventBus eventBus) {
     this.atSign = checkNotNull(atSign, "atSign not set");
     this.keys = checkNotNull(keys, "keys not set");
+    this.monitorOptions = monitorOptions != null ? monitorOptions : MonitorOptions.builder().build();
     this.config = config;
     this.executor = checkNotNull(executor, "executor not set");
     this.eventBus = checkNotNull(eventBus, "eventBus not set");
     this.eventBus.addEventListener(this::handleEvent, EnumSet.allOf(AtEventType.class));
-    this.eventBusBridge = new Notifications.EventBusBridge(eventBus, atSign);
+    this.isMonitoring.set(withMonitoring);
+    this.eventBusBridge = new Notifications.EventBusBridge(eventBus, atSign, this.monitorOptions);
     checkNotNull(keys.getEncryptPrivateKey(), "keys have not been fully enrolled");
   }
 
@@ -103,7 +108,6 @@ public class AtClientImpl implements AtClient {
     // required for javadoc
   }
 
-
   @Override
   public void close() throws Exception {
     executor.close();
@@ -112,7 +116,7 @@ public class AtClientImpl implements AtClient {
   @Override
   public void startMonitor() {
     isMonitoring.compareAndSet(false, true);
-    executor.onReady(Notifications.monitor(atSign, keys, config, eventBusBridge::accept));
+    executor.onReady(Notifications.monitor(atSign, monitorOptions, keys, config, eventBusBridge));
   }
 
   @Override

--- a/at_client/src/main/java/org/atsign/client/impl/AtClients.java
+++ b/at_client/src/main/java/org/atsign/client/impl/AtClients.java
@@ -60,7 +60,7 @@ public class AtClients {
     SimpleAtEventBus eventBus = new SimpleAtEventBus();
 
     if (monitorOptions == null) {
-      monitorOptions = MonitorOptions.builder().multiplexed(true).build();
+      monitorOptions = MonitorOptions.builder().build();
     }
 
     Consumer<AtCommandExecutor> onReady = null;

--- a/at_client/src/main/java/org/atsign/client/impl/AtClients.java
+++ b/at_client/src/main/java/org/atsign/client/impl/AtClients.java
@@ -4,8 +4,14 @@ import static org.atsign.client.impl.common.Preconditions.checkNotNull;
 
 import java.io.File;
 import java.util.Map;
+import java.util.function.Consumer;
 
-import org.atsign.client.api.*;
+import org.atsign.client.api.AtClient;
+import org.atsign.client.api.AtCommandExecutor;
+import org.atsign.client.api.AtKeys;
+import org.atsign.client.api.AtSign;
+import org.atsign.client.impl.commands.MonitorOptions;
+import org.atsign.client.impl.commands.Notifications;
 import org.atsign.client.impl.common.ReconnectStrategy;
 import org.atsign.client.impl.common.SimpleAtEventBus;
 import org.atsign.client.impl.common.SimpleReconnectStrategy;
@@ -14,6 +20,7 @@ import org.atsign.client.impl.exceptions.AtException;
 import org.atsign.client.impl.util.KeysUtils;
 
 import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Utility methods for instantiating {@link AtClient} implementations that are included in this
@@ -29,6 +36,7 @@ import lombok.Builder;
  * </pre>
  *
  */
+@Slf4j
 public class AtClients {
 
   @Builder(builderClassName = "AtClientBuilder")
@@ -36,6 +44,8 @@ public class AtClients {
                                         AtSign atSign,
                                         AtKeys keys,
                                         String keysPath,
+                                        boolean withMonitoring,
+                                        MonitorOptions monitorOptions,
                                         Map<String, Object> config,
                                         Long timeoutMillis,
                                         Long awaitReadyMillis,
@@ -47,10 +57,23 @@ public class AtClients {
     checkNotNull(atSign, "atSign not set");
     keys = keys != null ? keys : loadKeys(keysPath, atSign);
 
+    SimpleAtEventBus eventBus = new SimpleAtEventBus();
+
+    if (monitorOptions == null) {
+      monitorOptions = MonitorOptions.builder().multiplexed(true).build();
+    }
+
+    Consumer<AtCommandExecutor> onReady = null;
+    if (withMonitoring) {
+      Notifications.EventBusBridge eventBusBridge = new Notifications.EventBusBridge(eventBus, atSign, monitorOptions);
+      onReady = Notifications.monitor(atSign, monitorOptions, keys, config, eventBusBridge);
+    }
+
     AtCommandExecutor executor = AtCommandExecutors.builder()
         .url(url)
         .atSign(atSign)
         .keys(keys)
+        .onReady(onReady)
         .config(config)
         .timeoutMillis(timeoutMillis)
         .awaitReadyMillis(awaitReadyMillis)
@@ -59,11 +82,11 @@ public class AtClients {
         .isVerbose(isVerbose)
         .build();
 
-    SimpleAtEventBus eventBus = new SimpleAtEventBus();
-
     return AtClientImpl.builder()
         .atSign(atSign)
         .keys(keys)
+        .withMonitoring(withMonitoring)
+        .monitorOptions(monitorOptions)
         .config(config)
         .executor(executor)
         .eventBus(eventBus)
@@ -95,6 +118,7 @@ public class AtClients {
    *   .url(...)           // the url for the root server or proxy (optional)
    *   .keys(...)          // the AtKeys that this client will use (optional)
    *   .keysPath(...)      // the location for the AtKeys that this client will use (optional)
+   *   .withMonitoring()   // if true then monitoring is automatically started
    *   .config(...)        // the config map that will be passed during authentication (optional)
    *   .timeoutMillis()    // timeout after which commands will complete exceptionally (optional)
    *   .awaitReadyMillis() // how long to wait for executor to become ready during build() (optional)

--- a/at_client/src/main/java/org/atsign/client/impl/AtCommandExecutors.java
+++ b/at_client/src/main/java/org/atsign/client/impl/AtCommandExecutors.java
@@ -56,6 +56,7 @@ public class AtCommandExecutors {
   public static AtCommandExecutor createCommandExecutor(String url,
                                                         AtSign atSign,
                                                         AtKeys keys,
+                                                        Consumer<AtCommandExecutor> onReady,
                                                         Map<String, Object> config,
                                                         Long timeoutMillis,
                                                         Long awaitReadyMillis,
@@ -73,9 +74,9 @@ public class AtCommandExecutors {
         .isVerbose(isVerbose)
         .timeoutMillis(defaultIfNotSet(timeoutMillis, DEFAULT_TIMEOUT_MILLIS))
         .awaitReadyMillis(defaultIfNotSet(awaitReadyMillis, DEFAULT_TIMEOUT_MILLIS))
-        .reconnect(defaultIfNotSet(reconnect))
+        .reconnect(defaultIfNotSet(reconnect, SimpleReconnectStrategy.builder().build()))
         .queueLimit(queueLimit)
-        .onReady(createOnReady(atSign, keys, createClientConfig(config)))
+        .onReady(defaultIfNotSet(onReady, createOnReady(atSign, keys, createClientConfig(config))))
         .build();
   }
 
@@ -138,8 +139,8 @@ public class AtCommandExecutors {
     return onReady;
   }
 
-  private static ReconnectStrategy defaultIfNotSet(ReconnectStrategy reconnect) {
-    return reconnect != null ? reconnect : SimpleReconnectStrategy.builder().build();
+  private static <T> T defaultIfNotSet(T value, T defaultValue) {
+    return value != null ? value : defaultValue;
   }
 
   private static long defaultIfNotSet(Long l, long defaultValue) {

--- a/at_client/src/main/java/org/atsign/client/impl/cli/AbstractCli.java
+++ b/at_client/src/main/java/org/atsign/client/impl/cli/AbstractCli.java
@@ -16,10 +16,7 @@ import org.atsign.client.impl.netty.NettyAtCommandExecutor;
 import org.atsign.client.impl.netty.NettyAtCommandExecutor.NettyAtCommandExecutorBuilder;
 import org.atsign.client.impl.util.KeysUtils;
 
-import picocli.CommandLine.ITypeConverter;
 import picocli.CommandLine.Option;
-
-import static org.atsign.client.api.AtSign.createAtSign;
 
 /**
  * Base class for Command Line Interface utilities. Holds common fields such as root server
@@ -122,10 +119,4 @@ public abstract class AbstractCli<T extends AbstractCli<T>> {
     }
   }
 
-  static class AtSignConverter implements ITypeConverter<AtSign> {
-    @Override
-    public AtSign convert(String s) {
-      return createAtSign(s);
-    }
-  }
 }

--- a/at_client/src/main/java/org/atsign/client/impl/cli/AtSignConverter.java
+++ b/at_client/src/main/java/org/atsign/client/impl/cli/AtSignConverter.java
@@ -1,0 +1,16 @@
+package org.atsign.client.impl.cli;
+
+import org.atsign.client.api.AtSign;
+import picocli.CommandLine;
+
+import static org.atsign.client.api.AtSign.createAtSign;
+
+/**
+ * A Picocli converter for {@link AtSign}
+ */
+public class AtSignConverter implements CommandLine.ITypeConverter<AtSign> {
+  @Override
+  public AtSign convert(String s) {
+    return createAtSign(s);
+  }
+}

--- a/at_client/src/main/java/org/atsign/client/impl/commands/CommandBuilders.java
+++ b/at_client/src/main/java/org/atsign/client/impl/commands/CommandBuilders.java
@@ -124,7 +124,6 @@ public class CommandBuilders {
     if (options != null) {
       builder.append(options.strict() ? ":strict" : "")
           .append(options.selfNotification() ? ":selfNotifications" : "")
-          .append(options.multiplexed() ? ":multiplexed" : "")
           .append(options.epochMillis() > 0 ? ":" + options.epochMillis() : "")
           .append(options.regex() != null ? " " + options.regex().trim() : "");
     }
@@ -456,20 +455,6 @@ public class CommandBuilders {
   }
 
   /**
-   * The priority of key change operation
-   */
-  public enum NotifyPriority {
-    low, medium, high
-  }
-
-  /**
-   * The strategy of key change operation
-   */
-  public enum NotifyStrategy {
-    all, latest
-  }
-
-  /**
    * A builder to compose an At Protocol command with the
    * <b>notify:(update|delete):messageType:key</b> verb.
    * The <b>notify:(update|delete):messageType:key</b> verb is used to send key change notifications
@@ -483,8 +468,7 @@ public class CommandBuilders {
    * @throws IllegalArgumentException If mandatory fields are not set or if field values conflict.
    */
   @Builder(builderMethodName = "notifyKeyChangeCommandBuilder", builderClassName = "NotifyKeyChangeCommandBuilder")
-  public static String notifyKeyChange(String id, NotifyOperation operation, NotifyPriority priority,
-                                       NotifyStrategy strategy, Integer latestN, String notifier,
+  public static String notifyKeyChange(String id, NotifyOperation operation, Integer latestN, String notifier,
                                        Metadata metadata, AtKey key, String value, Long ttln) {
 
     checkNotNull(operation, "operation not set");
@@ -499,8 +483,6 @@ public class CommandBuilders {
         .append(id != null ? ":id:" + id : "")
         .append(":" + operation)
         .append(":messageType:key")
-        .append(priority != null ? ":priority:" + priority : "")
-        .append(strategy != null ? ":strategy:" + strategy : "")
         .append(latestN != null ? ":latestN:" + latestN : "")
         .append(notifier != null ? ":notifier:" + notifier : "")
         .append(ttln != null ? ":ttln:" + ttln : "")

--- a/at_client/src/main/java/org/atsign/client/impl/commands/CommandBuilders.java
+++ b/at_client/src/main/java/org/atsign/client/impl/commands/CommandBuilders.java
@@ -2,22 +2,20 @@ package org.atsign.client.impl.commands;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.atsign.client.api.Metadata.*;
 import static org.atsign.client.impl.common.Preconditions.*;
 import static org.atsign.client.impl.util.StringUtils.isBlank;
-import static org.atsign.client.api.Metadata.*;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.atsign.client.api.AtSign;
 import org.atsign.client.api.Keys;
+import org.atsign.client.api.Keys.AtKey;
 import org.atsign.client.api.Metadata;
 import org.atsign.client.impl.common.EnrollmentId;
-import org.atsign.client.impl.util.JsonUtils;
 import org.atsign.client.impl.common.TypedString;
-import org.atsign.client.api.Keys.AtKey;
-import org.atsign.client.api.Metadata.MetadataBuilder;
-
+import org.atsign.client.impl.util.JsonUtils;
 
 import lombok.Builder;
 
@@ -109,6 +107,28 @@ public class CommandBuilders {
         .append(enrollmentId != null ? ":enrollmentId:" + enrollmentId : "")
         .append(':').append(digest)
         .toString();
+  }
+
+
+  /**
+   * A builder to compose an At Protocol command with the <b>monitor</b> verb. The <b>monitor</b> verb
+   * is used to subscribe for notification messages.
+   *
+   * @param options optional arguments that control the server behavior
+   * @return A correctly formed <b>monitor</b> verb command.
+   * @throws IllegalArgumentException If mandatory fields are not set.
+   */
+  @Builder(builderMethodName = "monitorCommandBuilder", builderClassName = "MonitorCommandBuilder")
+  public static String monitor(MonitorOptions options) {
+    StringBuilder builder = new StringBuilder("monitor");
+    if (options != null) {
+      builder.append(options.strict() ? ":strict" : "")
+          .append(options.selfNotification() ? ":selfNotifications" : "")
+          .append(options.multiplexed() ? ":multiplexed" : "")
+          .append(options.epochMillis() > 0 ? ":" + options.epochMillis() : "")
+          .append(options.regex() != null ? " " + options.regex().trim() : "");
+    }
+    return builder.toString();
   }
 
   /**
@@ -436,43 +456,68 @@ public class CommandBuilders {
   }
 
   /**
+   * The priority of key change operation
+   */
+  public enum NotifyPriority {
+    low, medium, high
+  }
+
+  /**
+   * The strategy of key change operation
+   */
+  public enum NotifyStrategy {
+    all, latest
+  }
+
+  /**
    * A builder to compose an At Protocol command with the
    * <b>notify:(update|delete):messageType:key</b> verb.
    * The <b>notify:(update|delete):messageType:key</b> verb is used to send key change notifications
-   * to other
-   * {@link AtSign}s.
+   * to other {@link AtSign}s.
    *
    * @param operation Update or Delete.
-   * @param recipient The {@link AtSign} to send the notification to.
-   * @param sender The {@link AtSign} that is sending the notification.
-   * @param key The namespace qualified key name.
+   * @param key The key to send the notification for.
    * @param value The updated value for the key.
-   * @param ttr Sets the time to refresh (milliseconds).
+   * @param ttln Sets the time to live (milliseconds).
    * @return A correctly formed <b>notify:messageType:key</b> verb command.
    * @throws IllegalArgumentException If mandatory fields are not set or if field values conflict.
    */
   @Builder(builderMethodName = "notifyKeyChangeCommandBuilder", builderClassName = "NotifyKeyChangeCommandBuilder")
-  public static String notifyKeyChange(NotifyOperation operation, AtSign recipient, AtSign sender, String key,
-                                       String value,
-                                       Long ttr) {
+  public static String notifyKeyChange(String id, NotifyOperation operation, NotifyPriority priority,
+                                       NotifyStrategy strategy, Integer latestN, String notifier,
+                                       Metadata metadata, AtKey key, String value, Long ttln) {
 
-    checkNotBlank(key, "key not set");
     checkNotNull(operation, "operation not set");
+    checkNotNull(key, "key not set");
 
-    if (ttr != null) {
-      checkTrue(ttr >= -1, "ttr < -1");
-      checkNotBlank(value, "value not set (mandatory when ttr is set)");
+    if (ttln != null) {
+      checkTrue(ttln >= -1, "ttln < -1");
+      checkNotBlank(value, "value not set (mandatory when ttln is set)");
     }
 
-    return new StringBuilder("notify:")
-        .append(operation)
-        .append(":messageType:key:")
-        .append(ttr != null ? "ttr:" + ttr + ":" : "")
-        .append(recipient != null ? recipient + ":" : "")
-        .append(key)
-        .append(sender != null ? sender : "")
+    return new StringBuilder("notify")
+        .append(id != null ? ":id:" + id : "")
+        .append(":" + operation)
+        .append(":messageType:key")
+        .append(priority != null ? ":priority:" + priority : "")
+        .append(strategy != null ? ":strategy:" + strategy : "")
+        .append(latestN != null ? ":latestN:" + latestN : "")
+        .append(notifier != null ? ":notifier:" + notifier : "")
+        .append(ttln != null ? ":ttln:" + ttln : "")
+        .append(metadata != null ? metadata : "")
+        .append(":" + key.rawKey())
         .append(!isBlank(value) ? ":" + value : "")
         .toString();
+  }
+
+  /**
+   * A builder to compose an At Protocol command with the
+   * <b>notify:(update|delete):messageType:key</b> verb.
+   * The <b>notify:(update|delete):messageType:key</b> verb is used to send key change notifications
+   * to other {@link AtSign}s.
+   */
+  public static class NotifyKeyChangeCommandBuilder {
+    // required for javadoc
   }
 
   /**

--- a/at_client/src/main/java/org/atsign/client/impl/commands/MonitorOptions.java
+++ b/at_client/src/main/java/org/atsign/client/impl/commands/MonitorOptions.java
@@ -1,0 +1,48 @@
+package org.atsign.client.impl.commands;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+
+/**
+ * Models optional parameters to the monitor command.
+ */
+@Data
+@Builder
+@Accessors(fluent = true)
+public class MonitorOptions {
+
+  /**
+   * strict server will only send notifications which match the regex; no other 'control'
+   * notifications such as statsNotifications will be sent on this connection unless they match
+   * the regex
+   */
+  private boolean strict;
+
+  /**
+   * multiplexed the server will understand that this is a connection which the client is using
+   * not just for notifications but also for request-response interactions. In this case, the
+   * server will only send notifications when there is no request currently being handled
+   */
+  @Builder.Default
+  private boolean multiplexed = true;
+
+  /**
+   * server will only send notifications received at or after that timestamp
+   */
+  private long epochMillis;
+
+  /**
+   * server will only send notifications for the atsign that sends this command
+   */
+  private boolean selfNotification;
+
+  /**
+   * server will send notifications which match the regex. If 'strict' is set, then only
+   * those regex-matching notifications will be sent. If 'strict' is not set, then other
+   * 'control' notifications (e.g. the statsNotification) which don't necessarily match the
+   * regex will also be sent
+   */
+  String regex;
+}

--- a/at_client/src/main/java/org/atsign/client/impl/commands/MonitorOptions.java
+++ b/at_client/src/main/java/org/atsign/client/impl/commands/MonitorOptions.java
@@ -21,14 +21,6 @@ public class MonitorOptions {
   private boolean strict;
 
   /**
-   * multiplexed the server will understand that this is a connection which the client is using
-   * not just for notifications but also for request-response interactions. In this case, the
-   * server will only send notifications when there is no request currently being handled
-   */
-  @Builder.Default
-  private boolean multiplexed = true;
-
-  /**
    * server will only send notifications received at or after that timestamp
    */
   private long epochMillis;

--- a/at_client/src/main/java/org/atsign/client/impl/commands/Notifications.java
+++ b/at_client/src/main/java/org/atsign/client/impl/commands/Notifications.java
@@ -3,6 +3,7 @@ package org.atsign.client.impl.commands;
 import static org.atsign.client.api.AtEvents.AtEventType.*;
 import static org.atsign.client.impl.commands.AtExceptions.throwOnReadyException;
 import static org.atsign.client.impl.commands.AuthenticationCommands.authenticateWithPkam;
+import static org.atsign.client.impl.common.Preconditions.checkNotNull;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -35,14 +36,17 @@ public class Notifications {
    * with pkam prior to sending the monitor command.
    *
    * @param atSign The {@link AtSign} to authenticate.
+   * @param options optional arguments that influence the server behavior.
    * @param keys The {@link AtKeys} to authenticate with.
    * @param consumer A consumer that will be invoked with each notification.
+   * @return A consumer that can be provided as OnReady argument.
    */
   public static Consumer<AtCommandExecutor> monitor(AtSign atSign,
+                                                    MonitorOptions options,
                                                     AtKeys keys,
                                                     Map<String, Object> config,
                                                     Consumer<String> consumer) {
-    return throwOnReadyException(executor -> monitor(executor, atSign, keys, config, consumer));
+    return throwOnReadyException(executor -> monitor(executor, atSign, options, keys, config, consumer));
   }
 
   /**
@@ -50,16 +54,18 @@ public class Notifications {
    *
    * @param executor The {@link AtCommandExecutor} to use.
    * @param atSign The {@link AtSign} to authenticate.
+   * @param options optional arguments that influence the server behavior.
    * @param keys The {@link AtKeys} to authenticate with.
    * @param consumer A consumer that will be invoked with each notification.
    * @throws AtException If any of the commands fail.
    */
   public static void monitor(AtCommandExecutor executor,
                              AtSign atSign,
+                             MonitorOptions options,
                              AtKeys keys,
                              Consumer<String> consumer)
       throws AtException {
-    monitor(executor, atSign, keys, null, consumer);
+    monitor(executor, atSign, options, keys, null, consumer);
   }
 
   /**
@@ -67,13 +73,16 @@ public class Notifications {
    *
    * @param executor The {@link AtCommandExecutor} to use.
    * @param atSign The {@link AtSign} to authenticate.
+   * @param options optional arguments that influence the server behavior.
    * @param keys The {@link AtKeys} to authenticate with.
    * @param config The map of configuration values to send with the from command.
    * @param consumer A consumer that will be invoked with each notification.
+   *        notifications.
    * @throws AtException If any of the commands fail.
    */
   public static void monitor(AtCommandExecutor executor,
                              AtSign atSign,
+                             MonitorOptions options,
                              AtKeys keys,
                              Map<String, Object> config,
                              Consumer<String> consumer)
@@ -84,7 +93,8 @@ public class Notifications {
       authenticateWithPkam(executor, atSign, keys, config);
 
       // send monitor command
-      executor.sendSync("monitor", consumer);
+      String command = CommandBuilders.monitorCommandBuilder().options(options).build();
+      executor.sendSync(command, consumer);
 
     } catch (ExecutionException | InterruptedException e) {
       throw new RuntimeException(e);
@@ -113,15 +123,19 @@ public class Notifications {
 
     private final AtSign atSign;
 
-    public EventBusBridge(AtEvents.AtEventBus eventBus, AtSign atSign) {
-      this.eventBus = eventBus;
-      this.atSign = atSign;
+    private final MonitorOptions monitorOptions;
+
+    public EventBusBridge(AtEvents.AtEventBus eventBus, AtSign atSign, MonitorOptions monitorOptions) {
+      this.eventBus = checkNotNull(eventBus);
+      this.atSign = checkNotNull(atSign);
+      this.monitorOptions = monitorOptions;
     }
 
     @Override
     public void accept(String s) {
       try {
         Map<String, Object> eventData = matchNotification(s);
+        monitorOptions.epochMillis(inferMonitorOptionsEpochMillis(eventData));
         AtEvents.AtEventType eventType = toEventType(eventData);
         if (eventType == monitorException) {
           eventData.put("key", "__monitorException__");
@@ -131,6 +145,16 @@ public class Notifications {
         eventBus.publishEvent(eventType, eventData);
       } catch (Exception e) {
         log.error("unexpected exception processing : {}", s, e);
+      }
+    }
+
+    private static long inferMonitorOptionsEpochMillis(Map<String, Object> eventData) {
+      Number eventEpochMillis = (Number) eventData.get("epochMillis");
+      if (eventEpochMillis == null) {
+        log.warn("received event with no epochMillis : {}", eventData);
+        return 0;
+      } else {
+        return eventEpochMillis.longValue() + 1;
       }
     }
 
@@ -151,5 +175,6 @@ public class Notifications {
       }
       return monitorException;
     }
+
   }
 }

--- a/at_client/src/main/java/org/atsign/client/impl/commands/SharedKeyCommands.java
+++ b/at_client/src/main/java/org/atsign/client/impl/commands/SharedKeyCommands.java
@@ -275,7 +275,7 @@ public class SharedKeyCommands {
           .hash(EncryptionUtils.digest(otherPublicKey, HASHING_ALGO_SHA512))
           .hashingAlgo(HASHING_ALGO_SHA512)
           .build();
-      String checksum = digest(otherPublicKey, "MD5");
+      String checksum = digest(otherPublicKey, MD5);
 
       // compose an update command to store this key encrypted with the other (sharedWith) atsign's public key
       String encryptedForOther = rsaEncryptToBase64(aesKey, otherPublicKey);
@@ -308,13 +308,13 @@ public class SharedKeyCommands {
     }
   }
 
-  private static String getEncryptKey(AtCommandExecutor executor, AtSign sharedBy) throws AtException {
+  public static String getEncryptKey(AtCommandExecutor executor, AtSign atSign) throws AtException {
     try {
 
       // send plookup for atsign's public encryption key
       String plookupCommand = CommandBuilders.plookupCommandBuilder()
           .keyName(AtKeyNames.PUBLIC_ENCRYPT)
-          .sharedBy(sharedBy)
+          .sharedBy(atSign)
           .build();
       String plookupResponse = executor.sendSync(plookupCommand);
 

--- a/at_client/src/main/java/org/atsign/client/impl/commands/builders/NotifyUpdateSharedKeyCommandBuilder.java
+++ b/at_client/src/main/java/org/atsign/client/impl/commands/builders/NotifyUpdateSharedKeyCommandBuilder.java
@@ -27,8 +27,6 @@ public class NotifyUpdateSharedKeyCommandBuilder {
     metadataBuilder = Metadata.builder().isEncrypted(true);
     commandBuilder = CommandBuilders.notifyKeyChangeCommandBuilder()
         .operation(CommandBuilders.NotifyOperation.update)
-        .priority(CommandBuilders.NotifyPriority.low)
-        .strategy(CommandBuilders.NotifyStrategy.all)
         .notifier("SYSTEM")
         .ttln(TimeUnit.MINUTES.toMillis(1));
   }

--- a/at_client/src/main/java/org/atsign/client/impl/commands/builders/NotifyUpdateSharedKeyCommandBuilder.java
+++ b/at_client/src/main/java/org/atsign/client/impl/commands/builders/NotifyUpdateSharedKeyCommandBuilder.java
@@ -1,0 +1,70 @@
+package org.atsign.client.impl.commands.builders;
+
+import static org.atsign.client.impl.common.Preconditions.checkNotNull;
+import static org.atsign.client.impl.util.EncryptionUtils.*;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.atsign.client.api.Keys;
+import org.atsign.client.api.Metadata;
+import org.atsign.client.impl.commands.CommandBuilders;
+import org.atsign.client.impl.exceptions.AtEncryptionException;
+import org.atsign.client.impl.util.EncryptionUtils;
+
+/**
+ * Command builder for sending shared key update notify commands.
+ */
+public class NotifyUpdateSharedKeyCommandBuilder {
+
+  private final CommandBuilders.NotifyKeyChangeCommandBuilder commandBuilder;
+  private final Metadata.MetadataBuilder metadataBuilder;
+  private String sharedWithPublicKey;
+  private boolean reuseSharedKey;
+  private String sharedKey;
+
+  public NotifyUpdateSharedKeyCommandBuilder() {
+    metadataBuilder = Metadata.builder().isEncrypted(true);
+    commandBuilder = CommandBuilders.notifyKeyChangeCommandBuilder()
+        .operation(CommandBuilders.NotifyOperation.update)
+        .priority(CommandBuilders.NotifyPriority.low)
+        .strategy(CommandBuilders.NotifyStrategy.all)
+        .notifier("SYSTEM")
+        .ttln(TimeUnit.MINUTES.toMillis(1));
+  }
+
+  public NotifyUpdateSharedKeyCommandBuilder key(Keys.SharedKey key) {
+    commandBuilder.key(key);
+    return this;
+  }
+
+  public NotifyUpdateSharedKeyCommandBuilder reuseSharedKey(boolean reuse) {
+    this.reuseSharedKey = reuse;
+    return this;
+  }
+
+  public NotifyUpdateSharedKeyCommandBuilder sharedWithPublicKey(String key) throws AtEncryptionException {
+    sharedWithPublicKey = key;
+    Metadata.PublicKeyHash publicKeyHash = Metadata.PublicKeyHash.builder()
+        .hash(EncryptionUtils.digest(sharedWithPublicKey, HASHING_ALGO_SHA512))
+        .hashingAlgo(HASHING_ALGO_SHA512)
+        .build();
+    metadataBuilder.pubKeyHash(publicKeyHash);
+    metadataBuilder.pubKeyCS(digest(sharedWithPublicKey, MD5));
+    return this;
+  }
+
+  public String build(String text) throws AtEncryptionException {
+    checkNotNull(sharedWithPublicKey, "sharedWithPublicKey not set");
+    if (sharedKey == null || !reuseSharedKey) {
+      sharedKey = EncryptionUtils.generateAESKeyBase64();
+      metadataBuilder.sharedKeyEnc(rsaEncryptToBase64(sharedKey, sharedWithPublicKey));
+    }
+    String iv = EncryptionUtils.generateRandomIvBase64(16);
+    return commandBuilder
+        .id(UUID.randomUUID().toString())
+        .value(aesEncryptToBase64(text, sharedKey, iv))
+        .metadata(metadataBuilder.ivNonce(iv).build())
+        .build();
+  }
+}

--- a/at_client/src/main/java/org/atsign/client/impl/common/SimpleAtEventBus.java
+++ b/at_client/src/main/java/org/atsign/client/impl/common/SimpleAtEventBus.java
@@ -1,17 +1,17 @@
 package org.atsign.client.impl.common;
 
+import io.netty.util.concurrent.DefaultThreadFactory;
 import lombok.extern.slf4j.Slf4j;
 
 import static org.atsign.client.api.AtEvents.AtEventBus;
 import static org.atsign.client.api.AtEvents.AtEventListener;
 import static org.atsign.client.api.AtEvents.AtEventType;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 /**
  * Simple implementation of {@link AtEventBus} which will asynchronously dispatch
@@ -20,9 +20,17 @@ import java.util.concurrent.Executors;
 @Slf4j
 public class SimpleAtEventBus implements AtEventBus {
 
-  private final ExecutorService executor = Executors.newCachedThreadPool();
+  private final ExecutorService executor;
 
-  final Map<AtEventListener, Set<AtEventType>> eventListeners = new HashMap<>();
+  final Map<AtEventListener, Set<AtEventType>> eventListeners = new ConcurrentHashMap<>();
+
+  public SimpleAtEventBus(ExecutorService executor) {
+    this.executor = executor;
+  }
+
+  public SimpleAtEventBus() {
+    this(Executors.newSingleThreadExecutor(new DefaultThreadFactory("eventbus", true)));
+  }
 
   @SuppressWarnings("unused")
   public Map<AtEventListener, Set<AtEventType>> getEventListeners() {
@@ -31,21 +39,23 @@ public class SimpleAtEventBus implements AtEventBus {
 
   @Override
   public int publishEvent(AtEventType eventType, Map<String, Object> eventData) {
-    Set<Map.Entry<AtEventListener, Set<AtEventType>>> listenerEntries = eventListeners.entrySet();
-    int listenerCount = 0;
-    for (Map.Entry<AtEventListener, Set<AtEventType>> next : listenerEntries) {
+    List<AtEventListener> listeners = eventListeners.entrySet().stream()
+        .filter(entry -> entry.getValue().contains(eventType))
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toList());
+    executor.submit(() -> invokeListeners(eventType, eventData, listeners));
+    return listeners.size();
+  }
+
+  private static void invokeListeners(AtEventType eventType, Map<String, Object> eventData,
+                                      List<AtEventListener> listeners) {
+    for (AtEventListener listener : listeners) {
       try {
-        Set<AtEventType> eventTypes = next.getValue();
-        if (eventTypes.contains(eventType)) {
-          AtEventListener listener = next.getKey();
-          listenerCount++;
-          executor.submit(() -> listener.handleEvent(eventType, eventData));
-        }
+        listener.handleEvent(eventType, eventData);
       } catch (Exception e) {
-        log.error("caught exception from one of its event listeners", e);
+        log.error("event listener exception", e);
       }
     }
-    return listenerCount;
   }
 
   @Override

--- a/at_client/src/main/java/org/atsign/client/impl/netty/NettyAtCommandExecutor.java
+++ b/at_client/src/main/java/org/atsign/client/impl/netty/NettyAtCommandExecutor.java
@@ -22,7 +22,6 @@ import org.atsign.client.impl.AtEndpointSupplier;
 import org.atsign.client.impl.common.ReconnectStrategy;
 import org.atsign.client.impl.common.CommandElement;
 import org.atsign.client.impl.common.CommandQueue;
-import org.atsign.client.impl.common.Preconditions;
 import org.atsign.client.impl.exceptions.AtException;
 import org.atsign.client.impl.exceptions.AtOnReadyException;
 import org.atsign.client.impl.exceptions.AtSecondaryConnectException;
@@ -139,7 +138,7 @@ public class NettyAtCommandExecutor implements AtCommandExecutor {
                                    Clock clock,
                                    Logger log)
       throws AtException {
-    this.endpointSupplier = Preconditions.checkNotNull(endpoint, "endpoint is not set");
+    this.endpointSupplier = checkNotNull(endpoint, "endpoint is not set");
     this.maxFrameLength = defaultIfUnset(maxFrameLength, DEFAULT_MAX_FRAME_LENGTH);
     this.reconnectStrategy = defaultIfNull(reconnect, ReconnectStrategy.NONE);
     this.onReadyConsumer.set(defaultIfNull(onReady, c -> {

--- a/at_client/src/main/java/org/atsign/client/impl/util/EncryptionUtils.java
+++ b/at_client/src/main/java/org/atsign/client/impl/util/EncryptionUtils.java
@@ -41,6 +41,11 @@ public class EncryptionUtils {
    */
   public static final String HASHING_ALGO_SHA512 = "sha512";
 
+  /**
+   * The checksum algo
+   */
+  public static final String MD5 = "MD5";
+
   static {
     Security.addProvider(new BouncyCastleProvider());
   }

--- a/at_client/src/test/java/org/atsign/client/impl/AtClientImplTest.java
+++ b/at_client/src/test/java/org/atsign/client/impl/AtClientImplTest.java
@@ -109,7 +109,7 @@ class AtClientImplTest {
 
     // verify monitor is called
     ArgumentCaptor<Consumer<String>> monitorCaptor = ArgumentCaptor.forClass(Consumer.class);
-    verify(executor).sendSync(eq("monitor"), monitorCaptor.capture());
+    verify(executor).sendSync(eq("monitor:multiplexed"), monitorCaptor.capture());
 
     // invoke the consumer and verify that eventBus is invoked
     monitorCaptor.getValue().accept("notification:{\"id\":\"-1\",\"from\":\"@gary\"}");

--- a/at_client/src/test/java/org/atsign/client/impl/AtClientImplTest.java
+++ b/at_client/src/test/java/org/atsign/client/impl/AtClientImplTest.java
@@ -109,7 +109,7 @@ class AtClientImplTest {
 
     // verify monitor is called
     ArgumentCaptor<Consumer<String>> monitorCaptor = ArgumentCaptor.forClass(Consumer.class);
-    verify(executor).sendSync(eq("monitor:multiplexed"), monitorCaptor.capture());
+    verify(executor).sendSync(eq("monitor"), monitorCaptor.capture());
 
     // invoke the consumer and verify that eventBus is invoked
     monitorCaptor.getValue().accept("notification:{\"id\":\"-1\",\"from\":\"@gary\"}");

--- a/at_client/src/test/java/org/atsign/client/impl/cli/AtSignConverterTest.java
+++ b/at_client/src/test/java/org/atsign/client/impl/cli/AtSignConverterTest.java
@@ -1,0 +1,20 @@
+package org.atsign.client.impl.cli;
+
+import static org.atsign.client.api.AtSign.createAtSign;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+
+class AtSignConverterTest {
+
+  @Test
+  void testConvertReturnsExpectedValues() {
+    assertThat(new AtSignConverter().convert("alice"), equalTo(createAtSign("@alice")));
+    assertThat(new AtSignConverter().convert("@alice"), equalTo(createAtSign("@alice")));
+    assertThat(new AtSignConverter().convert(null), nullValue());
+    assertThat(new AtSignConverter().convert(""), nullValue());
+    assertThat(new AtSignConverter().convert(" "), nullValue());
+  }
+}

--- a/at_client/src/test/java/org/atsign/client/impl/commands/CommandBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/client/impl/commands/CommandBuildersTest.java
@@ -135,27 +135,23 @@ public class CommandBuildersTest {
 
     MonitorOptions options = MonitorOptions.builder().build();
     command = CommandBuilders.monitorCommandBuilder().options(options).build();
-    assertThat(command, equalTo("monitor:multiplexed"));
-
-    options = MonitorOptions.builder().multiplexed(false).build();
-    command = CommandBuilders.monitorCommandBuilder().options(options).build();
     assertThat(command, equalTo("monitor"));
 
-    options = MonitorOptions.builder().multiplexed(false).strict(true).build();
+    options = MonitorOptions.builder().strict(true).build();
     command = CommandBuilders.monitorCommandBuilder().options(options).build();
     assertThat(command, equalTo("monitor:strict"));
 
-    options = MonitorOptions.builder().multiplexed(false).strict(true).regex(".*bob.*").build();
+    options = MonitorOptions.builder().strict(true).regex(".*bob.*").build();
     command = CommandBuilders.monitorCommandBuilder().options(options).build();
     assertThat(command, equalTo("monitor:strict .*bob.*"));
 
     options = MonitorOptions.builder().selfNotification(true).build();
     command = CommandBuilders.monitorCommandBuilder().options(options).build();
-    assertThat(command, equalTo("monitor:selfNotifications:multiplexed"));
+    assertThat(command, equalTo("monitor:selfNotifications"));
 
     options = MonitorOptions.builder().epochMillis(12345000L).build();
     command = CommandBuilders.monitorCommandBuilder().options(options).build();
-    assertThat(command, equalTo("monitor:multiplexed:12345000"));
+    assertThat(command, equalTo("monitor:12345000"));
   }
 
   @Test

--- a/at_client/src/test/java/org/atsign/client/impl/commands/CommandBuildersTest.java
+++ b/at_client/src/test/java/org/atsign/client/impl/commands/CommandBuildersTest.java
@@ -128,6 +128,37 @@ public class CommandBuildersTest {
   }
 
   @Test
+  public void testMonitorBuilderGeneratesExpectedOutput() {
+
+    String command = CommandBuilders.monitorCommandBuilder().build();
+    assertThat(command, equalTo("monitor"));
+
+    MonitorOptions options = MonitorOptions.builder().build();
+    command = CommandBuilders.monitorCommandBuilder().options(options).build();
+    assertThat(command, equalTo("monitor:multiplexed"));
+
+    options = MonitorOptions.builder().multiplexed(false).build();
+    command = CommandBuilders.monitorCommandBuilder().options(options).build();
+    assertThat(command, equalTo("monitor"));
+
+    options = MonitorOptions.builder().multiplexed(false).strict(true).build();
+    command = CommandBuilders.monitorCommandBuilder().options(options).build();
+    assertThat(command, equalTo("monitor:strict"));
+
+    options = MonitorOptions.builder().multiplexed(false).strict(true).regex(".*bob.*").build();
+    command = CommandBuilders.monitorCommandBuilder().options(options).build();
+    assertThat(command, equalTo("monitor:strict .*bob.*"));
+
+    options = MonitorOptions.builder().selfNotification(true).build();
+    command = CommandBuilders.monitorCommandBuilder().options(options).build();
+    assertThat(command, equalTo("monitor:selfNotifications:multiplexed"));
+
+    options = MonitorOptions.builder().epochMillis(12345000L).build();
+    command = CommandBuilders.monitorCommandBuilder().options(options).build();
+    assertThat(command, equalTo("monitor:multiplexed:12345000"));
+  }
+
+  @Test
   public void testUpdateBuilderThrowsExceptionsWhenMandatoryFieldsAreNotSet() {
 
     IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
@@ -984,59 +1015,60 @@ public class CommandBuildersTest {
     IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                                                () -> CommandBuilders.notifyKeyChangeCommandBuilder()
                                                    .operation(NotifyOperation.update)
-                                                   .sender(createAtSign("sender"))
-                                                   .recipient(createAtSign("recipient"))
                                                    .build());
     assertThat(ex.getMessage(), containsString("key not set"));
 
+    SharedKey key = Keys.sharedKeyBuilder()
+        .name("key1")
+        .sharedBy(createAtSign("alice"))
+        .sharedWith(createAtSign("bob"))
+        .build();
+
     ex = assertThrows(IllegalArgumentException.class,
-                      () -> CommandBuilders.notifyKeyChangeCommandBuilder().key("key").build());
+                      () -> CommandBuilders.notifyKeyChangeCommandBuilder().key(key).build());
     assertThat(ex.getMessage(), containsString("operation not set"));
 
-    // Test setting the value when ttr has been set
+    // Test setting the value when ttln has been set
     ex = assertThrows(IllegalArgumentException.class, () -> CommandBuilders.notifyKeyChangeCommandBuilder()
         .operation(NotifyOperation.update)
-        .sender(createAtSign("sender"))
-        .recipient(createAtSign("recipient"))
-        .key("phone")
-        .ttr(10000L)
+        .key(key)
+        .ttln(10000L)
         .build());
-    assertThat(ex.getMessage(), containsString("value not set (mandatory when ttr is set)"));
+    assertThat(ex.getMessage(), containsString("value not set (mandatory when ttln is set)"));
 
-    // Test setting invalid ttr
+    // Test setting invalid ttln
     ex = assertThrows(IllegalArgumentException.class, () -> CommandBuilders.notifyKeyChangeCommandBuilder()
         .operation(NotifyOperation.update)
-        .sender(createAtSign("sender"))
-        .recipient(createAtSign("recipient"))
-        .key("phone")
-        .ttr(-100L)
+        .key(key)
+        .ttln(-100L)
         .build());
-    assertThat(ex.getMessage(), containsString("ttr < -1"));
+    assertThat(ex.getMessage(), containsString("ttln < -1"));
 
     // test command
     String command = CommandBuilders.notifyKeyChangeCommandBuilder()
         .operation(NotifyOperation.update)
-        .sender(createAtSign("sender"))
-        .recipient(createAtSign("recipient"))
-        .key("phone")
+        .id("1")
+        .key(key)
         .build();
-    assertThat(command, equalTo("notify:update:messageType:key:@recipient:phone@sender"));
+    assertThat(command, equalTo("notify:id:1:update:messageType:key:@bob:key1@alice"));
 
     // test command with a fully formed key
     command = CommandBuilders.notifyKeyChangeCommandBuilder()
         .operation(NotifyOperation.update)
-        .key("@recipient:phone@sender")
+        .id("1")
+        .key(key)
         .build();
-    assertThat(command, equalTo("notify:update:messageType:key:@recipient:phone@sender"));
+    assertThat(command, equalTo("notify:id:1:update:messageType:key:@bob:key1@alice"));
 
     // test command when ttr and value are present
     command = CommandBuilders.notifyKeyChangeCommandBuilder()
         .operation(NotifyOperation.update)
-        .key("@recipient:phone@sender")
-        .ttr(1000L)
+        .id("1")
+        .key(key)
+        .ttln(1000L)
         .value("cache_me")
         .build();
-    assertThat(command, equalTo("notify:update:messageType:key:ttr:1000:@recipient:phone@sender:cache_me"));
+    assertThat(command, equalTo("notify:id:1:update:messageType:key:ttln:1000:@bob:key1@alice:cache_me"));
   }
 
   @Test

--- a/at_client/src/test/java/org/atsign/client/impl/commands/NotificationsTest.java
+++ b/at_client/src/test/java/org/atsign/client/impl/commands/NotificationsTest.java
@@ -33,7 +33,7 @@ class NotificationsTest {
     stubAuthentication(executor, atSign);
 
     Consumer<String> consumer = mock(Consumer.class);
-    Notifications.monitor(executor, atSign, keys, consumer);
+    Notifications.monitor(executor, atSign, null, keys, consumer);
 
     verify(executor).sendSync(eq("monitor"), eq(consumer));
   }
@@ -50,7 +50,7 @@ class NotificationsTest {
     }).when(executor).sendSync(eq("monitor"), Mockito.any(Consumer.class));
 
     Exception ex =
-        assertThrows(Exception.class, () -> Notifications.monitor(atSign, keys, null, consumer).accept(executor));
+        assertThrows(Exception.class, () -> Notifications.monitor(atSign, null, keys, null, consumer).accept(executor));
     assertThat(ex, instanceOf(AtOnReadyException.class));
   }
 
@@ -70,7 +70,10 @@ class NotificationsTest {
   @Test
   void testEventBusBridgePublishesExpectedEventForStatsNotification() {
     AtEvents.AtEventBus eventBus = mock(AtEvents.AtEventBus.class);
-    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus, createAtSign("colin"));
+    MonitorOptions monitorOptions = MonitorOptions.builder().build();
+    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus,
+        createAtSign("colin"),
+        monitorOptions);
 
     consumer.accept("notification: {\"id\":\"-1\",\"from\":\"@gary\",\"to\":\"@gary\"" +
         ",\"key\":\"statsNotification.@gary\",\"value\":\"229\"" +
@@ -82,12 +85,16 @@ class NotificationsTest {
     assertThat(captor.getValue().get("id"), equalTo("-1"));
     assertThat(captor.getValue().get("operation"), equalTo("update"));
     assertThat(captor.getValue().get("epochMillis"), equalTo(100000));
+    assertThat(monitorOptions.epochMillis(), equalTo(100001L));
   }
 
   @Test
   void testEventBusBridgePublishesExpectedEventForSharedKeyNotification() {
     AtEvents.AtEventBus eventBus = mock(AtEvents.AtEventBus.class);
-    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus, createAtSign("gary"));
+    MonitorOptions monitorOptions = MonitorOptions.builder().build();
+    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus,
+        createAtSign("gary"),
+        monitorOptions);
 
     consumer.accept("notification: {\"id\":\"0480060d\",\"from\":\"@colin\"" +
         ",\"to\":\"@gary\",\"key\":\"@gary:shared_key@colin\"" +
@@ -106,7 +113,10 @@ class NotificationsTest {
   @Test
   void testEventBusBridgePublishesExpectedEventForUpdateNotification() {
     AtEvents.AtEventBus eventBus = mock(AtEvents.AtEventBus.class);
-    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus, createAtSign("gary"));
+    MonitorOptions monitorOptions = MonitorOptions.builder().build();
+    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus,
+        createAtSign("gary"),
+        monitorOptions);
 
     consumer.accept("notification: {\"id\":\"cc72371c\",\"from\":\"@colin\",\"to\":\"@gary\"" +
         ",\"key\":\"@gary:test@colin\",\"value\":\"C8gg7hDuJ4BVk6hrgu2GCQ==\",\"operation\":\"update\"" +
@@ -125,7 +135,10 @@ class NotificationsTest {
   @Test
   void testEventBusBridgeCatchesUnexpectedExceptions() {
     AtEvents.AtEventBus eventBus = mock(AtEvents.AtEventBus.class);
-    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus, createAtSign("gary"));
+    MonitorOptions monitorOptions = MonitorOptions.builder().build();
+    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus,
+        createAtSign("gary"),
+        monitorOptions);
 
     consumer.accept("xyz");
 
@@ -135,7 +148,10 @@ class NotificationsTest {
   @Test
   void testEventBusBridgePublishesExpectedEventForDeleteNotification() {
     AtEvents.AtEventBus eventBus = mock(AtEvents.AtEventBus.class);
-    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus, createAtSign("gary"));
+    MonitorOptions monitorOptions = MonitorOptions.builder().build();
+    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus,
+        createAtSign("gary"),
+        monitorOptions);
 
     consumer.accept("notification: {\"id\":\"41b265d8\",\"from\":\"@colin\",\"to\":\"@gary\"" +
         ",\"key\":\"@gary:test@colin\",\"value\":null,\"operation\":\"delete\",\"epochMillis\":1773077405537" +
@@ -153,7 +169,10 @@ class NotificationsTest {
   @Test
   void testEventBusBridgePublishesExpectedEventForUnrecognizedNotification() {
     AtEvents.AtEventBus eventBus = mock(AtEvents.AtEventBus.class);
-    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus, createAtSign("gary"));
+    MonitorOptions monitorOptions = MonitorOptions.builder().build();
+    Notifications.EventBusBridge consumer = new Notifications.EventBusBridge(eventBus,
+        createAtSign("gary"),
+        monitorOptions);
 
     consumer.accept("notification: {\"id\":\"41b265d8\",\"from\":\"@colin\",\"to\":\"@gary\"" +
         ",\"key\":\"@gary:test@colin\",\"value\":null,\"operation\":\"unrecognized\",\"epochMillis\":1773077405537" +
@@ -180,6 +199,5 @@ class NotificationsTest {
       }
     });
   }
-
 
 }

--- a/at_client/src/test/java/org/atsign/client/impl/commands/builders/NotifyUpdateSharedKeyCommandBuilderTest.java
+++ b/at_client/src/test/java/org/atsign/client/impl/commands/builders/NotifyUpdateSharedKeyCommandBuilderTest.java
@@ -1,0 +1,123 @@
+package org.atsign.client.impl.commands.builders;
+
+import static org.atsign.client.api.AtSign.createAtSign;
+import static org.atsign.client.impl.util.EncryptionUtils.generateRSAKeyPair;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.atsign.client.api.Keys;
+import org.atsign.client.impl.util.EncryptionUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class NotifyUpdateSharedKeyCommandBuilderTest {
+
+  private String sharedWithPublicKey;
+  private Keys.SharedKey key;
+  private NotifyUpdateSharedKeyCommandBuilder builder;
+
+  @BeforeEach
+  void setup() throws Exception {
+    sharedWithPublicKey = EncryptionUtils.toStringBase64(generateRSAKeyPair().getPublic());
+    key = Keys.sharedKeyBuilder()
+        .name("key1")
+        .sharedBy(createAtSign("alice"))
+        .sharedWith(createAtSign("bob"))
+        .build();
+    builder = new NotifyUpdateSharedKeyCommandBuilder()
+        .key(key)
+        .sharedWithPublicKey(sharedWithPublicKey);
+  }
+
+  @Test
+  void testBuildThrowsExceptionIfSharedWithPublicKeyNotSet() {
+    NotifyUpdateSharedKeyCommandBuilder builder = new NotifyUpdateSharedKeyCommandBuilder();
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> builder.build("message"));
+    assertThat(ex.getMessage(), containsString("sharedWithPublicKey not set"));
+  }
+
+  @Test
+  void testBuildThrowsExceptionIfKeyNotSet() throws Exception {
+    String sharedWithPublicKey = EncryptionUtils.toStringBase64(generateRSAKeyPair().getPublic());
+    NotifyUpdateSharedKeyCommandBuilder builder = new NotifyUpdateSharedKeyCommandBuilder();
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                                               () -> builder.sharedWithPublicKey(sharedWithPublicKey).build("message"));
+    assertThat(ex.getMessage(), containsString("key not set"));
+  }
+
+  @Test
+  void testBuildGeneratesExpectedCommand() throws Exception {
+    String command = builder.build("message");
+    String expected = new StringBuilder()
+        .append("notify:id:.+:update:messageType:key")
+        .append(":priority:low:strategy:all:notifier:SYSTEM:ttln:\\d+")
+        .append(":isEncrypted:true:sharedKeyEnc:.+:pubKeyCS:.+:pubKeyHash:.+:hashingAlgo:sha512:ivNonce:.+")
+        .append(":" + key.rawKey())
+        .append(":(.+)")
+        .toString();
+    assertThat(command, matchesPattern(expected));
+  }
+
+  @Test
+  void testUniqueId() throws Exception {
+    Set<String> ids = new HashSet<>();
+    Matcher idMatcher = Pattern.compile("notify:id:([^:])").matcher("");
+
+    idMatcher.reset(builder.build("message"));
+    assertThat(idMatcher.find(), is(true));
+    assertThat(ids.add(idMatcher.group(1)), is(true));
+
+    idMatcher.reset(builder.build("message"));
+    assertThat(idMatcher.find(), is(true));
+    assertThat(ids.add(idMatcher.group(1)), is(true));
+
+    idMatcher.reset(builder.build("a different message"));
+    assertThat(idMatcher.find(), is(true));
+    assertThat(ids.add(idMatcher.group(1)), is(true));
+  }
+
+  @Test
+  void testThatByDefaultSharedKeyIsUniqueForEachBuild() throws Exception {
+    Set<String> sharedKeyEncs = new HashSet<>();
+    Matcher sharedKeyEncMatcher = Pattern.compile("sharedKeyEnc:([^:])").matcher("");
+
+    sharedKeyEncMatcher.reset(builder.build("message"));
+    assertThat(sharedKeyEncMatcher.find(), is(true));
+    assertThat(sharedKeyEncs.add(sharedKeyEncMatcher.group(1)), is(true));
+
+    sharedKeyEncMatcher.reset(builder.build("message"));
+    assertThat(sharedKeyEncMatcher.find(), is(true));
+    assertThat(sharedKeyEncs.add(sharedKeyEncMatcher.group(1)), is(true));
+
+    sharedKeyEncMatcher.reset(builder.build("a different message"));
+    assertThat(sharedKeyEncMatcher.find(), is(true));
+    assertThat(sharedKeyEncs.add(sharedKeyEncMatcher.group(1)), is(true));
+  }
+
+
+  @Test
+  void testThatSharedKeyIsNotUniqueForEachBuildWhenReuseSharedKeyIsTrue() throws Exception {
+    builder.reuseSharedKey(true);
+    Set<String> sharedKeyEncs = new HashSet<>();
+    Matcher sharedKeyEncMatcher = Pattern.compile("sharedKeyEnc:([^:])").matcher("");
+
+    sharedKeyEncMatcher.reset(builder.build("message"));
+    assertThat(sharedKeyEncMatcher.find(), is(true));
+    assertThat(sharedKeyEncs.add(sharedKeyEncMatcher.group(1)), is(true));
+
+    sharedKeyEncMatcher.reset(builder.build("message"));
+    assertThat(sharedKeyEncMatcher.find(), is(true));
+    assertThat(sharedKeyEncs.add(sharedKeyEncMatcher.group(1)), is(false));
+
+    sharedKeyEncMatcher.reset(builder.build("a different message"));
+    assertThat(sharedKeyEncMatcher.find(), is(true));
+    assertThat(sharedKeyEncs.add(sharedKeyEncMatcher.group(1)), is(false));
+  }
+
+}

--- a/at_client/src/test/java/org/atsign/client/impl/commands/builders/NotifyUpdateSharedKeyCommandBuilderTest.java
+++ b/at_client/src/test/java/org/atsign/client/impl/commands/builders/NotifyUpdateSharedKeyCommandBuilderTest.java
@@ -56,7 +56,7 @@ class NotifyUpdateSharedKeyCommandBuilderTest {
     String command = builder.build("message");
     String expected = new StringBuilder()
         .append("notify:id:.+:update:messageType:key")
-        .append(":priority:low:strategy:all:notifier:SYSTEM:ttln:\\d+")
+        .append(":notifier:SYSTEM:ttln:\\d+")
         .append(":isEncrypted:true:sharedKeyEnc:.+:pubKeyCS:.+:pubKeyHash:.+:hashingAlgo:sha512:ivNonce:.+")
         .append(":" + key.rawKey())
         .append(":(.+)")
@@ -67,7 +67,7 @@ class NotifyUpdateSharedKeyCommandBuilderTest {
   @Test
   void testUniqueId() throws Exception {
     Set<String> ids = new HashSet<>();
-    Matcher idMatcher = Pattern.compile("notify:id:([^:])").matcher("");
+    Matcher idMatcher = Pattern.compile("notify:id:([^:]+)").matcher("");
 
     idMatcher.reset(builder.build("message"));
     assertThat(idMatcher.find(), is(true));

--- a/at_client/src/test/java/org/atsign/client/impl/common/SimpleAtEventBusTest.java
+++ b/at_client/src/test/java/org/atsign/client/impl/common/SimpleAtEventBusTest.java
@@ -1,0 +1,90 @@
+package org.atsign.client.impl.common;
+
+import org.atsign.client.api.AtEvents;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import static org.atsign.client.api.AtEvents.AtEventType.decryptedUpdateNotification;
+import static org.atsign.client.api.AtEvents.AtEventType.statsNotification;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class SimpleAtEventBusTest {
+
+  @Test
+  void testGetEventListenersReturnsExpectedList() {
+    ExecutorService executor = mock(ExecutorService.class);
+    SimpleAtEventBus bus = new SimpleAtEventBus(executor);
+
+    assertThat(bus.eventListeners, is(anEmptyMap()));
+
+    AtEvents.AtEventListener listener1 = mock(AtEvents.AtEventListener.class);
+    bus.addEventListener(listener1, Set.of(statsNotification));
+
+    assertThat(bus.eventListeners,
+               equalTo(Collections.singletonMap(listener1, Set.of(statsNotification))));
+
+    AtEvents.AtEventListener listener2 = mock(AtEvents.AtEventListener.class);
+    bus.addEventListener(listener2, Set.of(AtEvents.AtEventType.values()));
+
+    assertThat(bus.eventListeners.size(), equalTo(2));
+
+    bus.addEventListener(listener1, Set.of(AtEvents.AtEventType.decryptedUpdateNotification));
+
+    assertThat(bus.eventListeners.size(), equalTo(2));
+
+    bus.removeEventListener(listener1);
+
+    assertThat(bus.eventListeners,
+               equalTo(Collections.singletonMap(listener2, Set.of(AtEvents.AtEventType.values()))));
+
+    bus.removeEventListener(listener2);
+
+    assertThat(bus.eventListeners, is(anEmptyMap()));
+
+  }
+
+  @Test
+  void testPublishEventInvokesExecutorAndRunningThoseRunnablesInvokesListeners() {
+
+    ExecutorService executor = mock(ExecutorService.class);
+    SimpleAtEventBus bus = new SimpleAtEventBus(executor);
+    AtEvents.AtEventListener listener1 = mock(AtEvents.AtEventListener.class);
+    bus.addEventListener(listener1, Set.of(statsNotification));
+    AtEvents.AtEventListener listener2 = mock(AtEvents.AtEventListener.class);
+    bus.addEventListener(listener2, Set.of(AtEvents.AtEventType.values()));
+    doThrow(new RuntimeException("deliberate")).when(listener2)
+        .handleEvent(eq(decryptedUpdateNotification), ArgumentMatchers.any(Map.class));
+    AtEvents.AtEventListener listener3 = mock(AtEvents.AtEventListener.class);
+    bus.addEventListener(listener3, Set.of(decryptedUpdateNotification));
+
+    HashMap<String, Object> map = new HashMap<>();
+    map.put("somedata", "somevalue");
+    bus.publishEvent(statsNotification, map);
+    bus.publishEvent(decryptedUpdateNotification, map);
+
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor, times(2)).submit(captor.capture());
+    captor.getAllValues().forEach(Runnable::run);
+
+    verify(listener1).handleEvent(eq(statsNotification), eq(map));
+    verifyNoMoreInteractions(listener1);
+
+    verify(listener2).handleEvent(eq(statsNotification), eq(map));
+    verify(listener2).handleEvent(eq(decryptedUpdateNotification), eq(map));
+
+    verify(listener3).handleEvent(eq(decryptedUpdateNotification), eq(map));
+    verifyNoMoreInteractions(listener3);
+
+  }
+}

--- a/at_client/src/test/java/org/atsign/cucumber/steps/AtClientContext.java
+++ b/at_client/src/test/java/org/atsign/cucumber/steps/AtClientContext.java
@@ -21,6 +21,7 @@ import org.atsign.client.api.AtEvents;
 import org.atsign.client.api.AtKeys;
 import org.atsign.client.impl.AtClients;
 import org.atsign.client.impl.commands.DataResponses;
+import org.atsign.client.impl.commands.MonitorOptions;
 import org.atsign.client.impl.common.EnrollmentId;
 import org.atsign.client.impl.util.KeysUtils;
 import org.atsign.client.impl.exceptions.AtException;
@@ -333,18 +334,14 @@ public class AtClientContext {
         .url(rootHostAndPort)
         .atSign(atSign)
         .keys(keys)
+        .withMonitoring(withMonitor)
+        .monitorOptions(MonitorOptions.builder().epochMillis(System.currentTimeMillis()).build())
         .isVerbose(isVerbose())
         .build();
     AtClientEventListener listener = new AtClientEventListener(qualifiedAtSign);
     atClient.addEventListener(listener, ALL_EVENT_TYPES);
     clients.put(qualifiedAtSign, atClient);
     listeners.put(qualifiedAtSign, listener);
-    if (withMonitor) {
-      atClient.startMonitor();
-      // wait for and old notifications to arrive and then clear listener
-      Thread.sleep(SECONDS.toMillis(2));
-      listener.clear();
-    }
     return atClient;
   }
 

--- a/at_talk/README.md
+++ b/at_talk/README.md
@@ -1,0 +1,62 @@
+# AtTalk Shell
+
+Illustrative command line utility which uses the Java at_client library to provide a simple chat tool
+
+## Usage
+
+To see usage:
+
+```shell
+java -jar target/at_talk-0.0.1-SNAPSHOT.jar --help
+```
+
+To run shell against virtual env as @gary talking to @colin, run this...
+
+```shell
+java -jar target/at_talk-0.0.1-SNAPSHOT.jar -a gary -t colin -d vip.ve.atsign.zone
+```
+
+And then run the shell against the virtual env as @colin talking to @gary, run this...
+
+```shell
+java -jar target/at_talk-0.0.1-SNAPSHOT.jar -a colin -t gary -d vip.ve.atsign.zone
+```
+
+**Note:** This will default to looking in $HOME/.atsign for AtKeys.
+
+There are 3 ways to resolve this...
+
+1. Copy the demo data keys to to $HOME/.atsign
+2. Override the default location and key file suffix with java properties.
+3. Override the default location and key file suffix with environment properties.
+
+### Copying the demo data key files
+
+Copy all the files target/at_demo_data/lib/assets/atkeys to $HOME/.atsign
+AND rename the key files so that they have the suffux _key.atKeys.
+
+### Override with Java properties
+
+Add the following -D options to your command lines.
+
+```shell
+java -DATSIGN_KEYS_DIR=target/at_demo_data/lib/assets/atkeys \
+  -DATSIGN_KEYS_SUFFIX=.atKeys \
+  -jar target/at_talk-0.0.1-SNAPSHOT.jar -a gary -t colin -d vip.ve.atsign.zone
+```
+
+### Override with environment variables
+
+Set/export the following environment variables prior to running the shell.
+
+| Environment Variable | Value                                 |
+|----------------------|---------------------------------------|
+| ATSIGN_KEYS_DIR      | target/at_demo_data/lib/assets/atkeys |
+| ATSIGN_KEYS_SUFFIX   | .atKey                                | 
+
+**Note:** JDK 9+ has stricter JAR verification for cryptographic providers.
+This means that BouncyCastle cannot be included in the shaded jar (this would
+remove the signature). The maven build downloads the bouncycastle jar to
+target/lib and include this in the jar manifest classpath. If you copy the
+FAT jar elsewhere you need to ensure that lib dir, containing the bouncycastle
+jar is also copied too.

--- a/at_talk/pom.xml
+++ b/at_talk/pom.xml
@@ -3,14 +3,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.atsign</groupId>
     <artifactId>at_java_parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
 
-  <artifactId>at_shell</artifactId>
+  <artifactId>at_talk</artifactId>
 
   <properties>
     <config.spotless>../config/java-format.xml</config.spotless>
@@ -31,6 +30,34 @@
       <version>${version.jansi}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${version.log4j2}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${version.log4j2}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>${version.log4j2}</version>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -44,26 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
       </plugin>
 
       <plugin>
@@ -105,7 +112,7 @@
               </filters>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>org.atsign.client.cli.REPL</mainClass>
+                  <mainClass>org.atsign.attalk.AtTalk</mainClass>
                   <manifestEntries>
                     <Class-Path>lib/bcprov-jdk15to18-${version.bouncycastle}.jar</Class-Path>
                   </manifestEntries>

--- a/at_talk/src/main/java/org/atsign/attalk/AtTalk.java
+++ b/at_talk/src/main/java/org/atsign/attalk/AtTalk.java
@@ -1,0 +1,179 @@
+package org.atsign.attalk;
+
+import static org.atsign.client.api.AtEvents.AtEventType.decryptedUpdateNotification;
+import static org.atsign.client.api.AtSign.createAtSign;
+import static org.atsign.client.impl.commands.SharedKeyCommands.getEncryptKey;
+import static org.fusesource.jansi.Ansi.ansi;
+
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import org.atsign.client.api.AtClient;
+import org.atsign.client.api.AtEvents;
+import org.atsign.client.api.AtSign;
+import org.atsign.client.api.Keys;
+import org.atsign.client.impl.AtClients;
+import org.atsign.client.impl.cli.AtSignConverter;
+import org.atsign.client.impl.commands.builders.NotifyUpdateSharedKeyCommandBuilder;
+import org.atsign.client.impl.exceptions.AtException;
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.AnsiConsole;
+import org.fusesource.jansi.AnsiType;
+
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+
+/**
+ * A Java port of at_talk
+ */
+@Slf4j
+public class AtTalk implements Callable<Integer> {
+
+  public static final String KEYNAME = "attalk";
+
+  @Option(names = {"-k", "--key-file"}, description = "Your atSign's atKeys file if not in ~/.atsign/keys/")
+  private String keysPath;
+
+  @Option(required = true, names = {"-a", "--atsign"}, description = "Your atSign", converter = AtSignConverter.class)
+  private AtSign atSign;
+
+  @Option(required = true, names = {"-t", "--toatsign"}, description = "Talk to this atSign",
+      paramLabel = "@atsign", converter = AtSignConverter.class)
+  private AtSign toAtSign;
+
+  @Option(names = {"-d", "--root-domain"}, description = "Root Domain (defaults to root.atsign.org)")
+  private String rootDomain = "root.atsign.org";
+
+  @Option(names = {"-n", "--namespace"}, description = "Namespace (defaults to ai6bh)")
+  private String namespace = "ai6bh";
+
+  @Option(names = {"-v", "--verbose"}, description = "logs sent and received at commands as INFO")
+  private boolean verbose;
+  private Keys.SharedKey key;
+  private boolean hasConsole;
+  private NotifyUpdateSharedKeyCommandBuilder builder;
+
+  public static void main(String[] args) {
+    System.exit(execute(args));
+  }
+
+  public static int execute(String[] args) {
+    return new CommandLine(new AtTalk())
+        .setUsageHelpWidth(80)
+        .setAllowOptionsAsOptionParameters(true)
+        .execute(args);
+  }
+
+  @Override
+  public Integer call() throws Exception {
+
+    boolean hasTerminal = detectHasTerminal();
+    key = createSharedKey();
+    builder = new NotifyUpdateSharedKeyCommandBuilder().key(key);
+
+    System.out.print(ansi().cursorToColumn(0).bold().fg(Ansi.Color.BLUE).a("Connecting ... ").reset());
+
+    try (AtClient client = createAtClient()) {
+
+      System.out.println(ansi().fg(Ansi.Color.GREEN).a("Connected").reset());
+
+      // register for decrypted update notifications
+      client.addEventListener(this::onNotification, Set.of(decryptedUpdateNotification));
+
+      // set toAtSign's public key
+      builder.sharedWithPublicKey(getEncryptKey(client.getCommandExecutor(), toAtSign));
+
+      StringBuilder buffer = new StringBuilder();
+      Scanner scanner = new Scanner(System.in);
+      writePrompt();
+      while (scanner.hasNextLine()) {
+        String line = scanner.nextLine().trim();
+        if (isExit(line)) {
+          return 0;
+        } else if (isSwitchToAtSign(line)) {
+          setToAtSign(client, createAtSign(line));
+        } else if (!hasTerminal) {
+          buffer.append(line).append("\r\n");
+        } else {
+          client.getCommandExecutor().sendSync(builder.build(line));
+        }
+        if (hasTerminal) {
+          writePrompt();
+        }
+      }
+      scanner.close();
+
+      if (buffer.length() > 0) {
+        String s = ansi().fg(Ansi.Color.BLUE).a("Sending a file").reset().toString()
+            + ansi().fg(Ansi.Color.WHITE).a(buffer).reset().toString();
+        client.getCommandExecutor().sendSync(builder.build(s));
+      }
+    }
+    return 0;
+  }
+
+  private static boolean isExit(String line) {
+    return "/exit".equals(line);
+  }
+
+  private static boolean isSwitchToAtSign(String line) {
+    return line.matches("@.+");
+  }
+
+  private void setToAtSign(AtClient client, AtSign atSign) throws AtException {
+    toAtSign = atSign;
+    key = createSharedKey();
+    builder.key(key);
+    builder.sharedWithPublicKey(getEncryptKey(client.getCommandExecutor(), toAtSign));
+  }
+
+  private Keys.SharedKey createSharedKey() {
+    return Keys.sharedKeyBuilder()
+        .name(KEYNAME)
+        .namespace(namespace)
+        .sharedBy(atSign)
+        .sharedWith(toAtSign)
+        .build();
+  }
+
+  private AtClient createAtClient() throws AtException {
+    return AtClients.builder()
+        .url(rootDomain)
+        .keysPath(keysPath)
+        .atSign(atSign)
+        .withMonitoring(true)
+        .isVerbose(verbose)
+        .build();
+  }
+
+  private void writePrompt() {
+    System.out.print(ansi().bold().fg(Ansi.Color.RED).a(atSign + ": ").reset());
+  }
+
+  public void onNotification(AtEvents.AtEventType eventType, Map<String, Object> data) {
+    if (isKeyMatch(data)) {
+      System.out.print(ansi().cursorToColumn(0).eraseLine());
+      System.out.print(ansi().bold().fg(Ansi.Color.GREEN).a(toAtSign + ": ").reset());
+      System.out.print(ansi().fg(Ansi.Color.GREEN).a((String) data.get("decryptedValue")).reset());
+      System.out.println();
+      writePrompt();
+    }
+  }
+
+  private boolean isKeyMatch(Map<String, Object> data) {
+    String key = (String) data.get("key");
+    return key != null && key.contains(KEYNAME + "." + namespace);
+  }
+
+  private static boolean detectHasTerminal() {
+    try {
+      AnsiConsole.systemInstall();
+      return AnsiConsole.out().getType() != AnsiType.Unsupported;
+    } finally {
+      AnsiConsole.systemUninstall();
+    }
+  }
+}

--- a/at_talk/src/main/java/org/atsign/attalk/AtTalk.java
+++ b/at_talk/src/main/java/org/atsign/attalk/AtTalk.java
@@ -16,6 +16,7 @@ import org.atsign.client.api.AtSign;
 import org.atsign.client.api.Keys;
 import org.atsign.client.impl.AtClients;
 import org.atsign.client.impl.cli.AtSignConverter;
+import org.atsign.client.impl.commands.MonitorOptions;
 import org.atsign.client.impl.commands.builders.NotifyUpdateSharedKeyCommandBuilder;
 import org.atsign.client.impl.exceptions.AtException;
 import org.fusesource.jansi.Ansi;
@@ -53,7 +54,6 @@ public class AtTalk implements Callable<Integer> {
   @Option(names = {"-v", "--verbose"}, description = "logs sent and received at commands as INFO")
   private boolean verbose;
   private Keys.SharedKey key;
-  private boolean hasConsole;
   private NotifyUpdateSharedKeyCommandBuilder builder;
 
   public static void main(String[] args) {
@@ -145,6 +145,7 @@ public class AtTalk implements Callable<Integer> {
         .keysPath(keysPath)
         .atSign(atSign)
         .withMonitoring(true)
+        .monitorOptions(MonitorOptions.builder().selfNotification(true).build())
         .isVerbose(verbose)
         .build();
   }

--- a/at_talk/src/main/resources/log4j2.xml
+++ b/at_talk/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <File name="FileLogger" fileName="attalk.log">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </File>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="FileLogger"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,9 @@
     <version.netty>4.2.12.Final</version.netty>
     <version.picocli>4.7.6</version.picocli>
     <version.slf4j>2.0.13</version.slf4j>
+    <version.log4j2>2.25.3</version.log4j2>
     <version.lombok>1.18.30</version.lombok>
+    <version.jansi>2.4.0</version.jansi>
 
     <version.junit-jupiter>5.10.2</version.junit-jupiter>
     <version.junit-platform-suite>1.10.2</version.junit-platform-suite>
@@ -73,6 +75,7 @@
     <module>at_shell</module>
     <module>at_utils</module>
     <module>examples</module>
+    <module>at_talk</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes #328 
closes #382 

**- What I did**
* New module (not published) for at_talk. This illustrates subscribing to decrypted value events and demonstrates sending notify key updates
* Modifications to the monitoring support in AtClientImpl. The withMonitoring() builder option allows monitoring from construction and avoid having to invoke startMonitor(). MonitorOptions makes all the verb parameters available in Java api.
 
**- How I did it**
* Created MonitorOptions.java to model monitor verb parameters.
* Add withMonitoring() to AtClients builder.
* New module at_talk that generates a fatjar (see README)
* AtClientContext can now be simplified, can now use epochMillis (rather than a pause and discard) to prevent tests from "bleeding into each other".

**- How to verify it**
* Clean install, follow README instructions for at_talk
* Have tested with dart at_talk
* New features have test coverage and all unit and integration tests run as part of this pipeline

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: at_talk cli
