### PR TITLE
fix(build): support building and testing under JDK 25 (current LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Set up JDK 11 and maven cache
+      - name: Set up JDK 25 and maven cache
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
-          java-version: '11'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
       - name: Add virtual env entry to hosts file

--- a/at_client/src/test/java/org/atsign/client/impl/cli/CliIT.java
+++ b/at_client/src/test/java/org/atsign/client/impl/cli/CliIT.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
@@ -47,17 +48,13 @@ class CliIT {
 
   @Test
   public void testShareUsage() throws Exception {
-    int shareCode = runMainExpectSystemExit(() -> Share.main(new String[] {VIRTUAL_ENV_ROOT}));
-    assertThat(shareCode, not(equalTo(0)));
-
-    int scanCode = runMainExpectSystemExit(() -> Scan.main(new String[] {VIRTUAL_ENV_ROOT}));
-    assertThat(scanCode, not(equalTo(0)));
-
-    int getCode = runMainExpectSystemExit(() -> Get.main(new String[] {VIRTUAL_ENV_ROOT}));
-    assertThat(getCode, not(equalTo(0)));
-
-    int deleteCode = runMainExpectSystemExit(() -> Delete.main(new String[] {VIRTUAL_ENV_ROOT}));
-    assertThat(deleteCode, not(equalTo(0)));
+    // Each CLI prints usage and exits non-zero when given too few args. Run each main in a
+    // forked JVM and read its real exit code: System.exit can no longer be trapped in-process
+    // now that the Security Manager is gone (JDK 24, JEP 486).
+    assertThat(runMainInSubprocess(Share.class, VIRTUAL_ENV_ROOT), not(equalTo(0)));
+    assertThat(runMainInSubprocess(Scan.class, VIRTUAL_ENV_ROOT), not(equalTo(0)));
+    assertThat(runMainInSubprocess(Get.class, VIRTUAL_ENV_ROOT), not(equalTo(0)));
+    assertThat(runMainInSubprocess(Delete.class, VIRTUAL_ENV_ROOT), not(equalTo(0)));
   }
 
   @Test
@@ -113,12 +110,19 @@ class CliIT {
     assertThrows(AssertionError.class, () -> findLines(secondScanStdout, "\\s+0:\\s+.*" + keyname + ".*"));
   }
 
-  public static int runMainExpectSystemExit(Statement statement, String... stdin) throws Exception {
-    AtomicReference<String> stdout = new AtomicReference<>();
-    return SystemLambda.catchSystemExit(() -> stdout.set(SystemLambda.tapSystemErr(() -> {
-      SystemLambda.SystemInStub stub = SystemLambda.withTextFromSystemIn(String.join("\n", List.of(stdin)));
-      stub.execute(statement);
-    })));
+  /**
+   * Runs a CLI {@code main} in a forked JVM and returns its exit code. The code under test calls
+   * {@link System#exit}, which can no longer be intercepted in-process now that the Security
+   * Manager has been removed (JDK 24, JEP 486) and {@code System.setSecurityManager} throws. The
+   * child inherits this JVM's classpath and stdio.
+   */
+  public static int runMainInSubprocess(Class<?> mainClass, String... args) throws Exception {
+    List<String> command = new ArrayList<>(List.of(
+                                                   System.getProperty("java.home") + "/bin/java",
+                                                   "-cp", System.getProperty("java.class.path"),
+                                                   mainClass.getName()));
+    command.addAll(List.of(args));
+    return new ProcessBuilder(command).inheritIO().start().waitFor();
   }
 
   public static List<String> runMain(Statement statement, String... stdin) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,12 @@
     <version.picocli>4.7.6</version.picocli>
     <version.slf4j>2.0.13</version.slf4j>
     <version.log4j2>2.25.3</version.log4j2>
-    <version.lombok>1.18.30</version.lombok>
+    <version.lombok>1.18.46</version.lombok>
     <version.jansi>2.4.0</version.jansi>
 
     <version.junit-jupiter>5.10.2</version.junit-jupiter>
     <version.junit-platform-suite>1.10.2</version.junit-platform-suite>
-    <version.mockito>5.5.0</version.mockito>
+    <version.mockito>5.20.0</version.mockito>
     <version.hamcrest>2.2</version.hamcrest>
     <version.cucumber>7.14.0</version.cucumber>
     <version.testcontainers>2.0.3</version.testcontainers>
@@ -151,11 +151,6 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
-        <version>${version.mockito}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
         <version>${version.mockito}</version>
       </dependency>
@@ -200,6 +195,27 @@
   <build>
     <pluginManagement>
       <plugins>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.14.0</version>
+          <configuration>
+            <!--
+              JDK 23+ disabled implicit annotation-processor discovery, so Lombok
+              on the classpath is silently ignored and the build fails with
+              "cannot find symbol: method builder()/getXxx()". Declaring the
+              processor path explicitly keeps Lombok running on modern JDKs.
+            -->
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${version.lombok}</version>
+              </path>
+            </annotationProcessorPaths>
+          </configuration>
+        </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -299,7 +315,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.30.0</version>
+          <version>2.44.0</version>
           <configuration>
             <java>
               <eclipse>
@@ -358,7 +374,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.11</version>
+          <version>0.8.15</version>
           <executions>
             <execution>
               <id>prepare-agent</id>


### PR DESCRIPTION
**- What I did**
fix(build): support building and testing under JDK 25 (current LTS)

**- How I did it**
A clean build previously failed under modern JDKs. Run the Lombok annotation processor explicitly (JDK 23+ disabled implicit discovery), and update Spotless, JaCoCo and Mockito to JDK 25-capable versions. Compile target stays Java 11, so published artifacts are unchanged. CI now builds on temurin 25.

**- How to verify it**
Checks pass
